### PR TITLE
Rust cleanup & error frame metadata

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_arch="wasm32")']
+runner = ["wasmtime"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
     "titleBar.inactiveBackground": "#ffa50099",
     "titleBar.inactiveForeground": "#15202b99"
   },
-  "rust-analyzer.cargo.features": ["wasmrs/dump-frames"],
-  "cSpell.words": ["wasmrs", "wasi", "nanobus"]
+  "rust-analyzer.cargo.features": ["wasmrs/dump-frames"]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+If you would like to contribute to the project, please follow these guidelines:
+
+- Fork the repository
+- Create a new branch for your changes
+- Make your changes, including appropriate tests
+- Update the documentation as necessary
+- Run existing tests to ensure nothing has broken
+- Submit a pull request

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ WasmRS revolves around a handful of methods that allow the host and the guest to
 
 As in RSocket, wasmRS frames contain a stream ID allowing the destination to differentiate multiple frames for different transactions.
 
-For more information on the protocol, see the [wasmRS documentation](https://github.com/nanobus/iota/blob/main/docs/wasmrs.md) at the root of this project.
+For more information on the protocol, see the [wasmRS documentation](https://github.com/wasmrs/docs/blob/main/wasmrs.md) at the root of this project.
 
 ## Prerequisites
 
@@ -50,15 +50,15 @@ RUST_LOG=wasmrs=trace cargo run --bin request ...
 ## See also
 
 - [nanobus](https://github.com/nanobus/nanobus) as a way to run wasmRS modules
-- [apex](https://apexlang.io) to generate boilerplate for iotas and projects using wasmrs.
+- [apex](https://apexlang.io) to generate wasmrs boilerplate and scaffold projects using wasmrs.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/wasmrs/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/wasmrs/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/bins/ops/Cargo.toml
+++ b/bins/ops/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 description = "Print wasmRS operations from a .wasm file."
 license = "Apache-2.0"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/bins/ops/Cargo.toml
+++ b/bins/ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-ops"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Print wasmRS operations from a .wasm file."
 license = "Apache-2.0"
@@ -8,10 +8,10 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs = { path = "../../crates/wasmrs", version = "0.4.0" }
-wasmrs-codec = { path = "../../crates/wasmrs-codec", version = "0.4.1" }
-wasmrs-wasmtime = { path = "../../crates/wasmrs-wasmtime", version = "0.4.0" }
-wasmrs-host = { path = "../../crates/wasmrs-host", version = "0.4.0" }
+wasmrs = { path = "../../crates/wasmrs", version = "0.5.0" }
+wasmrs-codec = { path = "../../crates/wasmrs-codec", version = "0.5.0" }
+wasmrs-wasmtime = { path = "../../crates/wasmrs-wasmtime", version = "0.5.0" }
+wasmrs-host = { path = "../../crates/wasmrs-host", version = "0.5.0" }
 env_logger = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 futures = { workspace = true }

--- a/bins/request/Cargo.toml
+++ b/bins/request/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 description = "Make a request to a wasmRS .wasm file."
 license = "Apache-2.0"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/bins/request/Cargo.toml
+++ b/bins/request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-request"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Make a request to a wasmRS .wasm file."
 license = "Apache-2.0"
@@ -8,13 +8,13 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs = { path = "../../crates/wasmrs", version = "0.4.0", features = [
+wasmrs = { path = "../../crates/wasmrs", version = "0.5.0", features = [
   "record-frames"
 ] }
-wasmrs-rx = { path = "../../crates/wasmrs-rx", version = "0.4.0" }
-wasmrs-codec = { path = "../../crates/wasmrs-codec", version = "0.4.1" }
-wasmrs-wasmtime = { path = "../../crates/wasmrs-wasmtime", version = "0.4.0" }
-wasmrs-host = { path = "../../crates/wasmrs-host", version = "0.4.0" }
+wasmrs-rx = { path = "../../crates/wasmrs-rx", version = "0.5.0" }
+wasmrs-codec = { path = "../../crates/wasmrs-codec", version = "0.5.0" }
+wasmrs-wasmtime = { path = "../../crates/wasmrs-wasmtime", version = "0.5.0" }
+wasmrs-host = { path = "../../crates/wasmrs-host", version = "0.5.0" }
 env_logger = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 futures = { workspace = true }

--- a/bins/wasmrs-replay/Cargo.toml
+++ b/bins/wasmrs-replay/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 description = "Make a request to a wasmRS .wasm file."
 license = "Apache-2.0"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/bins/wasmrs-replay/Cargo.toml
+++ b/bins/wasmrs-replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-replay"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Make a request to a wasmRS .wasm file."
 license = "Apache-2.0"
@@ -8,14 +8,14 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs = { path = "../../crates/wasmrs", version = "0.4.0", features = [
+wasmrs = { path = "../../crates/wasmrs", version = "0.5.0", features = [
   "record-frames"
 ] }
-wasmrs-frames = { path = "../../crates/wasmrs-frames", version = "0.4.0" }
-wasmrs-rx = { path = "../../crates/wasmrs-rx", version = "0.4.0" }
-wasmrs-codec = { path = "../../crates/wasmrs-codec", version = "0.4.1" }
-wasmrs-testhost = { path = "../../crates/wasmrs-testhost", version = "0.4.0" }
-wasmrs-host = { path = "../../crates/wasmrs-host", version = "0.4.0" }
+wasmrs-frames = { path = "../../crates/wasmrs-frames", version = "0.5.0" }
+wasmrs-rx = { path = "../../crates/wasmrs-rx", version = "0.5.0" }
+wasmrs-codec = { path = "../../crates/wasmrs-codec", version = "0.5.0" }
+wasmrs-testhost = { path = "../../crates/wasmrs-testhost", version = "0.5.0" }
+wasmrs-host = { path = "../../crates/wasmrs-host", version = "0.5.0" }
 env_logger = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 futures = { workspace = true }

--- a/bins/wasmrs-replay/src/main.rs
+++ b/bins/wasmrs-replay/src/main.rs
@@ -3,7 +3,7 @@ use std::{io::Read, sync::Arc};
 use base64::Engine;
 use clap::Parser;
 use tracing::{debug, info};
-use wasmrs::{Payload, RSocket, SocketSide, WasmSocket};
+use wasmrs::{RSocket, RawPayload, SocketSide, WasmSocket};
 use wasmrs_frames::PayloadError;
 use wasmrs_host::WasiParams;
 use wasmrs_rx::*;
@@ -77,22 +77,22 @@ async fn main() -> anyhow::Result<()> {
 struct HostServer {}
 
 impl RSocket for HostServer {
-  fn fire_and_forget(&self, _req: Payload) -> Mono<(), PayloadError> {
+  fn fire_and_forget(&self, _req: RawPayload) -> Mono<(), PayloadError> {
     Mono::default()
   }
 
-  fn request_response(&self, _payload: Payload) -> Mono<Payload, PayloadError> {
+  fn request_response(&self, _payload: RawPayload) -> Mono<RawPayload, PayloadError> {
     Mono::default()
   }
 
-  fn request_stream(&self, _req: Payload) -> FluxReceiver<Payload, PayloadError> {
-    let (tx, rx) = Flux::new_channels();
+  fn request_stream(&self, _req: RawPayload) -> FluxReceiver<RawPayload, PayloadError> {
+    let (tx, rx) = FluxChannel::new_parts();
     tx.complete();
     rx
   }
 
-  fn request_channel(&self, _reqs: FluxReceiver<Payload, PayloadError>) -> FluxReceiver<Payload, PayloadError> {
-    let (tx, rx) = Flux::new_channels();
+  fn request_channel(&self, _reqs: Box<dyn Flux<RawPayload, PayloadError>>) -> FluxReceiver<RawPayload, PayloadError> {
+    let (tx, rx) = FluxChannel::new_parts();
     tx.complete();
     rx
   }

--- a/crates/wasmrs-codec/Cargo.toml
+++ b/crates/wasmrs-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-codec"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "MessagePack Codec implementation used by wasmRS modules"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 [features]
 
 [dependencies]
-wasmrs-frames = { path = "../wasmrs-frames", version = "0.4.0" }
+wasmrs-frames = { path = "../wasmrs-frames", version = "0.5.0" }
 wasm-msgpack = { version = "0.4" }
 serde = { version = "1", features = [], default-features = false }
 heapless = "0.7"

--- a/crates/wasmrs-codec/Cargo.toml
+++ b/crates/wasmrs-codec/Cargo.toml
@@ -2,9 +2,9 @@
 name = "wasmrs-codec"
 version = "0.4.1"
 edition = "2021"
-description = "MessagePack Codec implementation used by wasmRS iotas"
+description = "MessagePack Codec implementation used by wasmRS modules"
 license = "Apache-2.0"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/crates/wasmrs-codec/README.md
+++ b/crates/wasmrs-codec/README.md
@@ -4,15 +4,15 @@ This crate provides the MessagePack encoding/decoding implementation for wasmRS 
 
 ## Usage
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-codec/src/error.rs
+++ b/crates/wasmrs-codec/src/error.rs
@@ -19,8 +19,9 @@ impl core::fmt::Display for Error {
 impl From<Error> for wasmrs_frames::PayloadError {
   fn from(val: Error) -> Self {
     use core::fmt::Write;
+
     let mut string: heapless::String<256> = heapless::String::new();
-    write!(string, "{:.256}", val).unwrap();
+    string.write_fmt(format_args!("{:.256}", val)).unwrap();
 
     wasmrs_frames::PayloadError::new(0, string.as_str())
   }

--- a/crates/wasmrs-codec/src/error.rs
+++ b/crates/wasmrs-codec/src/error.rs
@@ -23,6 +23,6 @@ impl From<Error> for wasmrs_frames::PayloadError {
     let mut string: heapless::String<256> = heapless::String::new();
     string.write_fmt(format_args!("{:.256}", val)).unwrap();
 
-    wasmrs_frames::PayloadError::new(0, string.as_str())
+    wasmrs_frames::PayloadError::new(0, string.as_str(), None)
   }
 }

--- a/crates/wasmrs-frames/Cargo.toml
+++ b/crates/wasmrs-frames/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 description = "WasmRS RSocket frame decoding, encoding, and data structures"
 license = "Apache-2.0"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 [features]
 default = []

--- a/crates/wasmrs-frames/Cargo.toml
+++ b/crates/wasmrs-frames/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-frames"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "WasmRS RSocket frame decoding, encoding, and data structures"
 license = "Apache-2.0"

--- a/crates/wasmrs-frames/README.md
+++ b/crates/wasmrs-frames/README.md
@@ -4,15 +4,15 @@ This crate provides the encoding, decoding, and data structures for wasmRS RSock
 
 ## More Information
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
-WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/nanobus/nanobus/blob/main/docs/getting-started.md) for nanobus for up-to-date usage.
+WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/WasmRS/docs/blob/main/wasmrs-rust-howto.md) for usage.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 

--- a/crates/wasmrs-frames/src/error.rs
+++ b/crates/wasmrs-frames/src/error.rs
@@ -1,5 +1,7 @@
 //! Library-specific error types and utility functions
 
+use bytes::Bytes;
+
 use crate::frames::ErrorCode;
 
 /// Error type for wasmRS RSocket errors.
@@ -16,8 +18,15 @@ pub enum Error {
   WrongType,
   /// Could not convert string from passed bytes.
   StringConversion,
-  /// [crate::Metadata] not found in [crate::Payload]
+  /// Did not find necessary [crate::Metadata] on a payload.
   MetadataNotFound,
+  /// A problem with extra metadata on [crate::Metadata].
+  Extra(String),
+}
+
+/// A utility method for creating an Error::Extra variant.
+pub fn ex_err(msg: impl AsRef<str>) -> Error {
+  Error::Extra(msg.as_ref().to_owned())
 }
 
 impl std::error::Error for Error {}
@@ -29,17 +38,21 @@ impl std::fmt::Display for Error {
       Error::ReceiverAlreadyGone => f.write_str("Received already taken"),
       Error::WrongType => f.write_str("Tried to decode frame with wrong frame decoder"),
       Error::StringConversion => f.write_str("Could not read string bytes"),
-      Error::MetadataNotFound => f.write_str("No metadata found"),
+      Error::Extra(m) => f.write_str(m),
+      Error::MetadataNotFound => f.write_str("Metadata missing"),
     }
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "derive_serde", derive(serde::Serialize, serde::Deserialize))]
 #[must_use]
 /// The error type used for all [wasmrs_rx::Mono]/[wasmrs_rx::Flux] payloads.
 pub struct PayloadError {
   /// The error code.
   pub code: u32,
+  /// Metadata associated with the error.
+  pub metadata: Option<Bytes>,
   /// The error message.
   pub msg: String,
 }
@@ -49,14 +62,25 @@ impl PayloadError {
   pub fn new(code: u32, msg: impl AsRef<str>) -> Self {
     Self {
       code,
+      metadata: None,
+      msg: msg.as_ref().to_owned(),
+    }
+  }
+
+  /// todo better name
+  pub fn new_md(msg: impl AsRef<str>) -> Self {
+    Self {
+      code: ErrorCode::ApplicationError.into(),
+      metadata: None,
       msg: msg.as_ref().to_owned(),
     }
   }
 
   /// Create a new [PayloadError] with the [ErrorCode::ApplicationError] code.
-  pub fn application_error(msg: impl AsRef<str>) -> Self {
+  pub fn application_error(msg: impl AsRef<str>, metadata: Option<Bytes>) -> Self {
     Self {
       code: ErrorCode::ApplicationError.into(),
+      metadata,
       msg: msg.as_ref().to_owned(),
     }
   }
@@ -87,5 +111,5 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for PayloadError {
 }
 
 fn app_err(e: &dyn std::error::Error) -> PayloadError {
-  PayloadError::application_error(e.to_string())
+  PayloadError::application_error(e.to_string(), None)
 }

--- a/crates/wasmrs-frames/src/error.rs
+++ b/crates/wasmrs-frames/src/error.rs
@@ -59,19 +59,10 @@ pub struct PayloadError {
 
 impl PayloadError {
   /// Create a new [PayloadError] with the passed code and message.
-  pub fn new(code: u32, msg: impl AsRef<str>) -> Self {
+  pub fn new(code: u32, msg: impl AsRef<str>, metadata: Option<Bytes>) -> Self {
     Self {
       code,
-      metadata: None,
-      msg: msg.as_ref().to_owned(),
-    }
-  }
-
-  /// todo better name
-  pub fn new_md(msg: impl AsRef<str>) -> Self {
-    Self {
-      code: ErrorCode::ApplicationError.into(),
-      metadata: None,
+      metadata,
       msg: msg.as_ref().to_owned(),
     }
   }

--- a/crates/wasmrs-frames/src/frames/f_payload.rs
+++ b/crates/wasmrs-frames/src/frames/f_payload.rs
@@ -2,7 +2,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 use super::{Error, FrameFlags, FrameHeader, FrameType, RSocketFlags, RSocketFrame};
 use crate::util::{from_u24_bytes, to_u24_bytes};
-use crate::{Frame, Payload};
+use crate::{Frame, RawPayload};
 
 /// A Payload frame.
 #[derive(Clone)]
@@ -24,7 +24,7 @@ pub struct PayloadFrame {
 }
 
 impl PayloadFrame {
-  pub(crate) fn from_payload(stream_id: u32, payload: Payload, flags: FrameFlags) -> Self {
+  pub(crate) fn from_payload(stream_id: u32, payload: RawPayload, flags: FrameFlags) -> Self {
     Self {
       stream_id,
       metadata: payload.metadata.unwrap_or_default(),
@@ -107,9 +107,9 @@ impl RSocketFrame<PayloadFrame> for PayloadFrame {
   }
 }
 
-impl From<PayloadFrame> for Payload {
+impl From<PayloadFrame> for RawPayload {
   fn from(req: PayloadFrame) -> Self {
-    Payload {
+    RawPayload {
       metadata: Some(req.metadata),
       data: Some(req.data),
     }

--- a/crates/wasmrs-frames/src/frames/f_payload.rs
+++ b/crates/wasmrs-frames/src/frames/f_payload.rs
@@ -19,7 +19,7 @@ pub struct PayloadFrame {
   pub follows: bool,
   /// Whether or not this frame is the last frame in a stream.
   pub complete: bool,
-  /// TODO
+  /// Whether or not this frame is followed by another frame.
   pub next: bool,
 }
 

--- a/crates/wasmrs-frames/src/frames/f_request_channel.rs
+++ b/crates/wasmrs-frames/src/frames/f_request_channel.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 
 use super::{request_payload::RequestPayload, Error, FrameFlags, FrameHeader, FrameType, RSocketFrame};
-use crate::{Frame, Payload};
+use crate::{Frame, RawPayload};
 
 #[cfg_attr(not(target = "wasm32-unknown-unknown"), derive(Debug))]
 #[must_use]
@@ -9,7 +9,7 @@ use crate::{Frame, Payload};
 pub struct RequestChannel(pub RequestPayload);
 
 impl RequestChannel {
-  pub(crate) fn from_payload(stream_id: u32, payload: Payload, flags: FrameFlags, initial_n: u32) -> Self {
+  pub(crate) fn from_payload(stream_id: u32, payload: RawPayload, flags: FrameFlags, initial_n: u32) -> Self {
     Self(RequestPayload::from_payload(
       stream_id,
       payload,
@@ -50,7 +50,7 @@ impl RSocketFrame<RequestChannel> for RequestChannel {
   }
 }
 
-impl From<RequestChannel> for Payload {
+impl From<RequestChannel> for RawPayload {
   fn from(req: RequestChannel) -> Self {
     req.0.into()
   }

--- a/crates/wasmrs-frames/src/frames/f_request_fnf.rs
+++ b/crates/wasmrs-frames/src/frames/f_request_fnf.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 
 use super::{request_payload::RequestPayload, Error, FrameFlags, FrameHeader, FrameType, RSocketFrame};
-use crate::{Frame, Payload};
+use crate::{Frame, RawPayload};
 
 #[cfg_attr(not(target = "wasm32-unknown-unknown"), derive(Debug))]
 #[must_use]
@@ -9,7 +9,7 @@ use crate::{Frame, Payload};
 pub struct RequestFnF(pub RequestPayload);
 
 impl RequestFnF {
-  pub(crate) fn from_payload(stream_id: u32, payload: Payload, flags: FrameFlags, initial_n: u32) -> Self {
+  pub(crate) fn from_payload(stream_id: u32, payload: RawPayload, flags: FrameFlags, initial_n: u32) -> Self {
     Self(RequestPayload::from_payload(
       stream_id,
       payload,
@@ -50,7 +50,7 @@ impl RSocketFrame<RequestFnF> for RequestFnF {
   }
 }
 
-impl From<RequestFnF> for Payload {
+impl From<RequestFnF> for RawPayload {
   fn from(req: RequestFnF) -> Self {
     req.0.into()
   }

--- a/crates/wasmrs-frames/src/frames/f_request_response.rs
+++ b/crates/wasmrs-frames/src/frames/f_request_response.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 
 use super::{request_payload::RequestPayload, Error, FrameFlags, FrameHeader, FrameType, RSocketFrame};
-use crate::{Frame, Payload};
+use crate::{Frame, RawPayload};
 
 #[cfg_attr(not(target = "wasm32-unknown-unknown"), derive(Debug))]
 #[must_use]
@@ -9,7 +9,7 @@ use crate::{Frame, Payload};
 pub struct RequestResponse(pub RequestPayload);
 
 impl RequestResponse {
-  pub(crate) fn from_payload(stream_id: u32, payload: Payload, flags: FrameFlags, initial_n: u32) -> Self {
+  pub(crate) fn from_payload(stream_id: u32, payload: RawPayload, flags: FrameFlags, initial_n: u32) -> Self {
     Self(RequestPayload::from_payload(
       stream_id,
       payload,
@@ -50,7 +50,7 @@ impl RSocketFrame<RequestResponse> for RequestResponse {
   }
 }
 
-impl From<RequestResponse> for Payload {
+impl From<RequestResponse> for RawPayload {
   fn from(req: RequestResponse) -> Self {
     req.0.into()
   }

--- a/crates/wasmrs-frames/src/frames/f_request_stream.rs
+++ b/crates/wasmrs-frames/src/frames/f_request_stream.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 
 use super::{request_payload::RequestPayload, Error, FrameFlags, FrameHeader, FrameType, RSocketFrame};
-use crate::{Frame, Payload};
+use crate::{Frame, RawPayload};
 
 #[cfg_attr(not(target = "wasm32-unknown-unknown"), derive(Debug))]
 #[must_use]
@@ -9,7 +9,7 @@ use crate::{Frame, Payload};
 pub struct RequestStream(pub RequestPayload);
 
 impl RequestStream {
-  pub(crate) fn from_payload(stream_id: u32, payload: Payload, flags: FrameFlags, initial_n: u32) -> Self {
+  pub(crate) fn from_payload(stream_id: u32, payload: RawPayload, flags: FrameFlags, initial_n: u32) -> Self {
     Self(RequestPayload::from_payload(
       stream_id,
       payload,
@@ -50,7 +50,7 @@ impl RSocketFrame<RequestStream> for RequestStream {
   }
 }
 
-impl From<RequestStream> for Payload {
+impl From<RequestStream> for RawPayload {
   fn from(req: RequestStream) -> Self {
     req.0.into()
   }

--- a/crates/wasmrs-frames/src/frames/header.rs
+++ b/crates/wasmrs-frames/src/frames/header.rs
@@ -91,14 +91,13 @@ impl std::fmt::Display for FrameHeader {
     }
 
     let t = self.frame_type();
-
-    write!(
-      f,
-      "FrameHeader{{id={},type={},flag={}}}",
-      self.stream_id(),
-      t,
-      flags.join("|")
-    )
+    f.write_str("FrameHeader{{id=")?;
+    self.stream_id().fmt(f)?;
+    f.write_str(",type=")?;
+    t.fmt(f)?;
+    f.write_str(",flag=")?;
+    flags.join("|").fmt(f)?;
+    f.write_str("}}")
   }
 }
 

--- a/crates/wasmrs-frames/src/frames/request_payload.rs
+++ b/crates/wasmrs-frames/src/frames/request_payload.rs
@@ -2,7 +2,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 use super::{Error, FrameFlags, FrameHeader, FrameType, RSocketFlags};
 use crate::util::{from_u24_bytes, from_u32_bytes, to_u24_bytes};
-use crate::{Frame, Payload};
+use crate::{Frame, RawPayload};
 
 #[derive(Clone)]
 #[cfg_attr(not(target = "wasm32-unknown-unknown"), derive(Debug))]
@@ -26,7 +26,7 @@ pub struct RequestPayload {
 impl RequestPayload {
   pub(super) fn from_payload(
     stream_id: u32,
-    payload: Payload,
+    payload: RawPayload,
     frame_type: FrameType,
     flags: FrameFlags,
     initial_n: u32,
@@ -116,9 +116,9 @@ impl RequestPayload {
   }
 }
 
-impl From<RequestPayload> for Payload {
+impl From<RequestPayload> for RawPayload {
   fn from(req: RequestPayload) -> Self {
-    Payload {
+    RawPayload {
       metadata: Some(req.metadata),
       data: Some(req.data),
     }

--- a/crates/wasmrs-frames/src/lib.rs
+++ b/crates/wasmrs-frames/src/lib.rs
@@ -82,7 +82,6 @@ mod frames;
 pub use frames::*;
 
 mod error;
-pub use error::Error;
-pub use error::PayloadError;
+pub use error::{ex_err, Error, PayloadError};
 
 pub(crate) mod util;

--- a/crates/wasmrs-guest/Cargo.toml
+++ b/crates/wasmrs-guest/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "wasmRS guest implementation of the RSocket protocol for reactive streams in WebAssembly."
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 [features]
 default = []

--- a/crates/wasmrs-guest/Cargo.toml
+++ b/crates/wasmrs-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-guest"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "wasmRS guest implementation of the RSocket protocol for reactive streams in WebAssembly."
@@ -13,11 +13,11 @@ record-frames = ["wasmrs/record-frames"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.4.0" }
-wasmrs-rx = { path = "../wasmrs-rx", version = "0.4.0" }
-wasmrs-codec = { path = "../wasmrs-codec", version = "0.4.1" }
-wasmrs = { path = "../wasmrs", version = "0.4.0" }
-wasmrs-frames = { path = "../wasmrs-frames", version = "0.4.0" }
+wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.5.0" }
+wasmrs-rx = { path = "../wasmrs-rx", version = "0.5.0" }
+wasmrs-codec = { path = "../wasmrs-codec", version = "0.5.0" }
+wasmrs = { path = "../wasmrs", version = "0.5.0" }
+wasmrs-frames = { path = "../wasmrs-frames", version = "0.5.0" }
 bytes = { workspace = true, default-features = false, features = ["serde"] }
 futures-executor = { workspace = true, default-features = false, features = [
   "std",

--- a/crates/wasmrs-guest/README.md
+++ b/crates/wasmrs-guest/README.md
@@ -35,7 +35,7 @@ fn request_response(input: Mono<ParsedPayload, PayloadError>) -> Result<Mono<Pay
 fn request_stream(
   input: Mono<ParsedPayload, PayloadError>,
 ) -> Result<FluxReceiver<Payload, PayloadError>, GenericError> {
-  let channel = Flux::<Payload, PayloadError>::new();
+  let channel = FluxChannel::<Payload, PayloadError>::new();
   let rx = channel.take_rx().unwrap();
   spawn(async move {
     let input = deserialize::<String>(&input.await.unwrap().data).unwrap();
@@ -51,7 +51,7 @@ fn request_stream(
 fn request_channel(
   mut input: FluxReceiver<ParsedPayload, PayloadError>,
 ) -> Result<FluxReceiver<Payload, PayloadError>, GenericError> {
-  let channel = Flux::<Payload, PayloadError>::new();
+  let channel = FluxChannel::<Payload, PayloadError>::new();
   let rx = channel.take_rx().unwrap();
   spawn(async move {
     while let Some(payload) = input.next().await {
@@ -86,17 +86,17 @@ From there, edit the `apex.axdl` interface definition to match your needs and ru
 
 ## More Information
 
-WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/nanobus/nanobus/blob/main/docs/getting-started.md) for NanoBus for up-to-date usage.
+WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/WasmRS/docs/blob/main/wasmrs-rust-howto.md) for usage.
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-guest/src/error.rs
+++ b/crates/wasmrs-guest/src/error.rs
@@ -8,16 +8,18 @@ pub enum Error {
   /// Error reading frame buffer.
   BufferRead,
   /// Internal Error.
-  Internal(wasmrs::Error),
+  Internal(String),
   /// Error decoding payload or metadata.
   Codec(String),
   /// Error in the asynchronous runtime.
   Runtime(String),
+  /// Missing input in payload.
+  MissingInput(String),
 }
 
 impl From<wasmrs::Error> for Error {
   fn from(e: wasmrs::Error) -> Self {
-    Self::Internal(e)
+    Self::Internal(e.to_string())
   }
 }
 
@@ -43,6 +45,11 @@ impl std::fmt::Display for Error {
       Error::Internal(e) => f.write_str(&e.to_string()),
       Error::Codec(e) => f.write_str(e),
       Error::Runtime(e) => f.write_str(e),
+      Error::MissingInput(e) => {
+        let mut message = "Missing input: ".to_owned();
+        message.push_str(e);
+        f.write_str(e)
+      }
     }
   }
 }
@@ -54,6 +61,12 @@ impl From<std::io::Error> for Error {
 
 impl From<wasmrs_frames::Error> for Error {
   fn from(value: wasmrs_frames::Error) -> Self {
-    Error::Internal(value.into())
+    Error::Internal(value.to_string())
+  }
+}
+
+impl From<wasmrs_rx::Error> for Error {
+  fn from(value: wasmrs_rx::Error) -> Self {
+    Error::Internal(value.to_string())
   }
 }

--- a/crates/wasmrs-guest/src/guest.rs
+++ b/crates/wasmrs-guest/src/guest.rs
@@ -131,7 +131,7 @@ pub(crate) fn send_frame(read_until: u32) {
   let read_result = read_frames(read_until);
   if read_result.is_err() {
     tracing::error!("could not read local buffer");
-    send_error_frame(0, 0, "Could not read local buffer");
+    send_error_frame(0, PayloadError::new(0, "Could not read local buffer", None));
     return;
   }
   let bytes_list = read_result.unwrap();
@@ -144,7 +144,7 @@ pub(crate) fn send_frame(read_until: u32) {
           let _ = socket.process_once(frame);
         }
         Err(_e) => {
-          send_error_frame(0, 0, "Could not decode frame data");
+          send_error_frame(0, PayloadError::new(0, "Could not decode frame data", None));
           continue;
         }
       }
@@ -178,8 +178,8 @@ fn read_frames(read_until: u32) -> Result<Vec<Bytes>, Error> {
   })
 }
 
-fn send_error_frame(stream_id: u32, code: u32, msg: impl AsRef<str>) {
-  let err = Frame::new_error(stream_id, code, msg.as_ref());
+fn send_error_frame(stream_id: u32, e: PayloadError) {
+  let err = Frame::new_error(stream_id, e);
   send_host_frame(vec![err.encode()]);
 }
 

--- a/crates/wasmrs-guest/src/lib.rs
+++ b/crates/wasmrs-guest/src/lib.rs
@@ -79,10 +79,11 @@
 #![allow(clippy::needless_pass_by_value)]
 
 mod guest;
+pub use error::Error;
 pub use futures_util::FutureExt;
 pub use guest::*;
 pub use wasmrs_runtime as runtime;
-pub use wasmrs_rx::*;
+pub use wasmrs_rx::{Flux, FluxChannel, FluxReceiver, Mono, Observable, Observer};
 
 mod exports;
 mod imports;
@@ -93,11 +94,12 @@ pub mod error;
 
 pub use futures_util::Stream;
 pub use serde_json::Value;
+pub use wasmrs::Payload;
 pub use wasmrs_codec::Timestamp;
 
 /// Deserialize a generic [Value] from MessagePack bytes.
 pub fn deserialize_generic(buf: &[u8]) -> Result<std::collections::BTreeMap<String, Value>, Error> {
-  deserialize(buf).map_err(|e| Error::Decode(e.to_string()))
+  deserialize(buf).map_err(|e| Error::Codec(e.to_string()))
 }
 
 cfg_if::cfg_if!(

--- a/crates/wasmrs-guest/src/server.rs
+++ b/crates/wasmrs-guest/src/server.rs
@@ -1,139 +1,138 @@
 use std::cell::UnsafeCell;
-use std::rc::Rc;
 
 use futures_util::StreamExt;
-use wasmrs::{Payload, RSocket};
+use runtime::RtRc;
+use wasmrs::{OperationMap, Payload, RSocket, RawPayload};
 use wasmrs_frames::PayloadError;
 use wasmrs_runtime as runtime;
-use wasmrs_rx::*;
+use wasmrs_rx::{Flux, FluxChannel, FluxReceiver, Mono, Observer};
 
 use crate::error::Error;
-use crate::{OperationMap, ParsedPayload};
-
-macro_rules! flux_try {
-  ($expr:expr) => {{
-    match $expr {
-      Ok(v) => v,
-      Err(e) => {
-        let flux = Flux::new();
-        let _ = flux.error(PayloadError::application_error(e.to_string()));
-        return flux.take_rx().unwrap();
-      }
-    }
-  }};
-  ($tx:ident, $expr:expr) => {{
-    match $expr {
-      Ok(v) => v,
-      Err(e) => {
-        let _ = $tx.error(PayloadError::application_error(e.to_string()));
-        return;
-      }
-    }
-  }};
-}
-
-macro_rules! mono_try {
-  ($expr:expr) => {{
-    match $expr {
-      Ok(v) => v,
-      Err(e) => return Mono::new_error(PayloadError::application_error(e.to_string())),
-    }
-  }};
-}
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub(crate) struct WasmServer {}
 
 impl RSocket for WasmServer {
-  fn fire_and_forget(&self, payload: Payload) -> Mono<(), PayloadError> {
-    let metadata = mono_try!(payload.parse_metadata());
-
-    let handler = mono_try!(get_process_handler(
-      &crate::guest::REQUEST_FNF_HANDLERS,
-      metadata.index as _,
-    ));
-
-    let parsed: ParsedPayload = mono_try!(payload.try_into());
-
-    mono_try!(handler(Mono::new_success(parsed)).map_err(|e| Error::HandlerFail(e.to_string())));
-
-    Mono::new_success(())
+  fn fire_and_forget(&self, payload: RawPayload) -> Mono<(), PayloadError> {
+    match request_fnf(payload) {
+      Ok(v) => Mono::new_success(v),
+      Err(e) => Mono::new_error(PayloadError::application_error(e.to_string(), None)),
+    }
   }
 
-  fn request_response(&self, payload: Payload) -> Mono<Payload, PayloadError> {
-    let metadata = mono_try!(payload.parse_metadata());
-
-    let handler = mono_try!(get_process_handler(
-      &crate::guest::REQUEST_RESPONSE_HANDLERS,
-      metadata.index as _,
-    ));
-
-    let parsed: ParsedPayload = mono_try!(payload.try_into());
-
-    mono_try!(handler(Mono::new_success(parsed)).map_err(|e| Error::HandlerFail(e.to_string())))
+  fn request_response(&self, payload: RawPayload) -> Mono<RawPayload, PayloadError> {
+    match request_response(payload) {
+      Ok(v) => v,
+      Err(e) => Mono::new_error(PayloadError::application_error(e.to_string(), None)),
+    }
   }
 
-  fn request_stream(&self, payload: Payload) -> FluxReceiver<Payload, PayloadError> {
-    let metadata = flux_try!(payload.parse_metadata());
-
-    let handler = flux_try!(get_process_handler(
-      &crate::guest::REQUEST_STREAM_HANDLERS,
-      metadata.index as _,
-    ));
-
-    let parsed: ParsedPayload = flux_try!(payload.try_into());
-    let mono = Mono::new_success(parsed);
-
-    flux_try!(handler(mono).map_err(|e| Error::HandlerFail(e.to_string())))
-  }
-
-  fn request_channel(&self, mut stream: FluxReceiver<Payload, PayloadError>) -> FluxReceiver<Payload, PayloadError> {
-    let (tx, rx) = Flux::new_channels();
-
-    runtime::spawn(async move {
-      let (handler_input, handler_stream) = Flux::new_channels();
-      let mut handler_out = if let Some(result) = stream.next().await {
-        let payload = flux_try!(tx, result);
-
-        let metadata = flux_try!(tx, payload.parse_metadata());
-        let handler = flux_try!(
-          tx,
-          get_process_handler(&crate::guest::REQUEST_CHANNEL_HANDLERS, metadata.index as _,)
-        );
-
-        handler_input.send(payload.try_into().unwrap()).unwrap();
-        flux_try!(
-          tx,
-          handler(handler_stream).map_err(|e| Error::HandlerFail(e.to_string()))
-        )
-      } else {
-        let _ = tx.error(PayloadError::application_error(
-          "Can not initiate a channel with no payload",
-        ));
-        return;
-      };
-      runtime::spawn(async move {
-        while let Some(payload) = handler_out.next().await {
-          let _ = tx.send_result(payload);
-        }
-        tx.complete();
-      });
-      while let Some(next) = stream.next().await {
-        let _ = handler_input.send_result(next.and_then(|v| {
-          v.try_into()
-            .map_err(|e: Error| PayloadError::application_error(e.to_string()))
-        }));
+  fn request_stream(&self, payload: RawPayload) -> FluxReceiver<RawPayload, PayloadError> {
+    match request_stream(payload) {
+      Ok(flux) => flux,
+      Err(e) => {
+        let flux = FluxChannel::new();
+        let _ = flux.error(PayloadError::application_error(e.to_string(), None));
+        flux.take_rx().unwrap()
       }
-    });
-
-    rx
+    }
   }
+
+  fn request_channel(&self, stream: Box<dyn Flux<RawPayload, PayloadError>>) -> FluxReceiver<RawPayload, PayloadError> {
+    match request_channel(stream) {
+      Ok(flux) => flux,
+      Err(e) => {
+        let flux = FluxChannel::new();
+        let _ = flux.error(PayloadError::application_error(e.to_string(), None));
+        flux.take_rx().unwrap()
+      }
+    }
+  }
+}
+
+fn request_fnf(payload: RawPayload) -> Result<(), Error> {
+  let parsed: Payload = payload.try_into()?;
+
+  let handler = get_process_handler(&crate::guest::REQUEST_FNF_HANDLERS, parsed.metadata.index as _)?;
+
+  handler(Mono::new_success(parsed)).map_err(|e| Error::HandlerFail(e.to_string()))?;
+  Ok(())
+}
+
+fn request_response(payload: RawPayload) -> Result<Mono<RawPayload, PayloadError>, Error> {
+  let parsed: Payload = payload.try_into()?;
+
+  let handler = get_process_handler(&crate::guest::REQUEST_RESPONSE_HANDLERS, parsed.metadata.index as _)?;
+
+  handler(Mono::new_success(parsed)).map_err(|e| Error::HandlerFail(e.to_string()))
+}
+
+fn request_stream(payload: RawPayload) -> Result<FluxReceiver<RawPayload, PayloadError>, Error> {
+  let parsed: Payload = payload.try_into()?;
+  let handler = get_process_handler(&crate::guest::REQUEST_STREAM_HANDLERS, parsed.metadata.index as _)?;
+  let mono = Mono::new_success(parsed);
+  handler(mono).map_err(|e| Error::HandlerFail(e.to_string()))
+}
+
+fn request_channel(
+  stream: Box<dyn Flux<RawPayload, PayloadError>>,
+) -> Result<FluxReceiver<RawPayload, PayloadError>, Error> {
+  let (tx, rx) = FluxChannel::new_parts();
+  runtime::spawn(async move {
+    if let Err(e) = request_channel_inner(tx.clone(), stream).await {
+      let _ = tx.error(PayloadError::application_error(e.to_string(), None));
+    }
+  });
+  Ok(rx)
+}
+
+async fn request_channel_inner(
+  tx: FluxChannel<RawPayload, PayloadError>,
+  mut stream: Box<dyn Flux<RawPayload, PayloadError>>,
+) -> Result<(), Error> {
+  let (handler_input, handler_stream) = FluxChannel::new_parts();
+  let mut handler_out = if let Some(result) = stream.next().await {
+    let payload = match result {
+      Ok(v) => v,
+      Err(e) => {
+        let _ = tx.error(e);
+        return Ok(());
+      }
+    };
+
+    let parsed: Payload = payload.try_into()?;
+    let handler = get_process_handler(&crate::guest::REQUEST_CHANNEL_HANDLERS, parsed.metadata.index as _)?;
+
+    handler_input.send(parsed).unwrap();
+
+    handler(handler_stream).map_err(|e| Error::HandlerFail(e.to_string()))?
+  } else {
+    let _ = tx.error(PayloadError::application_error(
+      "Can not initiate a channel with no payload",
+      None,
+    ));
+    return Ok(());
+  };
+  runtime::spawn(async move {
+    while let Some(payload) = handler_out.next().await {
+      let _ = tx.send_result(payload);
+    }
+    tx.complete();
+  });
+  while let Some(next) = stream.next().await {
+    let v = next.and_then(|v: RawPayload| {
+      v.try_into()
+        .map_err(|e: wasmrs::Error| PayloadError::application_error(e.to_string(), None))
+    });
+    let _ = handler_input.send_result(v);
+  }
+  Ok(())
 }
 
 fn get_process_handler<T>(
   kind: &'static std::thread::LocalKey<UnsafeCell<OperationMap<T>>>,
   index: usize,
-) -> Result<Rc<T>, Error> {
+) -> Result<RtRc<T>, Error> {
   kind.with(|cell| {
     #[allow(unsafe_code)]
     let buffer = unsafe { &*cell.get() };

--- a/crates/wasmrs-host/Cargo.toml
+++ b/crates/wasmrs-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-host"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "wasmRS host implementation for executing and interactin with wasmRS modules."
@@ -8,10 +8,10 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs-frames = { path = "../wasmrs-frames", version = "0.4.0" }
-wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.4.0" }
-wasmrs-rx = { path = "../wasmrs-rx", version = "0.4.0" }
-wasmrs = { path = "../wasmrs", version = "0.4.0" }
+wasmrs-frames = { path = "../wasmrs-frames", version = "0.5.0" }
+wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.5.0" }
+wasmrs-rx = { path = "../wasmrs-rx", version = "0.5.0" }
+wasmrs = { path = "../wasmrs", version = "0.5.0" }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/wasmrs-host/Cargo.toml
+++ b/crates/wasmrs-host/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "wasmRS host implementation for executing and interactin with wasmRS modules."
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/crates/wasmrs-host/README.md
+++ b/crates/wasmrs-host/README.md
@@ -1,24 +1,24 @@
 # wasmrs-host
 
-This crate provides the host-side logic to run wasmRS modules. It delegates the WebAssembly interpreter implementation to engine providers like [wasmrs-wasmtime](https://github.com/nanobus/iota/blob/rust/crates/wasmrs-wasmtime).
+This crate provides the host-side logic to run wasmRS modules. It delegates the WebAssembly interpreter implementation to engine providers like [wasmrs-wasmtime](https://github.com/wasmrs/wasmrs-rust/blob/main//crates/wasmrs-wasmtime).
 
 ## Engine providers
 
-- [wasmrs-wasmtime](https://github.com/nanobus/iota/blob/rust/crates/wasmrs-wasmtime)
+- [wasmrs-wasmtime](https://github.com/wasmrs/wasmrs-rust/blob/main//crates/wasmrs-wasmtime)
 
 ## Usage
 
-For more information on using wasmRS-host, see examples in the [wasmrs-wasmtime](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs-wasmtime/README.md) crate.
+For more information on using wasmRS-host, see examples in the [wasmrs-wasmtime](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs-wasmtime/README.md) crate.
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-host/src/protocol.rs
+++ b/crates/wasmrs-host/src/protocol.rs
@@ -53,7 +53,7 @@ impl AsRef<str> for HostExports {
 
 impl std::fmt::Display for HostExports {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.as_ref())
+    f.write_str(self.as_ref())
   }
 }
 
@@ -113,6 +113,6 @@ impl AsRef<str> for GuestExports {
 
 impl std::fmt::Display for GuestExports {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.as_ref())
+    f.write_str(self.as_ref())
   }
 }

--- a/crates/wasmrs-runtime/Cargo.toml
+++ b/crates/wasmrs-runtime/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Base host and client implementations of the wasmRS RSocket protocol."
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/crates/wasmrs-runtime/Cargo.toml
+++ b/crates/wasmrs-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-runtime"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Base host and client implementations of the wasmRS RSocket protocol."
@@ -8,7 +8,7 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs-frames = { path = "../wasmrs-frames", version = "0.4.0" }
+wasmrs-frames = { path = "../wasmrs-frames", version = "0.5.0" }
 futures = { workspace = true, default-features = false }
 bytes = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = false }

--- a/crates/wasmrs-runtime/README.md
+++ b/crates/wasmrs-runtime/README.md
@@ -8,17 +8,17 @@ You're better off not relying on this crate. It's a crate that exists only for a
 
 ## More Info
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
-WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/nanobus/nanobus/blob/main/docs/getting-started.md) for nanobus for up-to-date usage.
+WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/WasmRS/docs/blob/main/wasmrs-rust-howto.md) for usage.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-runtime/src/error.rs
+++ b/crates/wasmrs-runtime/src/error.rs
@@ -19,9 +19,3 @@ impl std::fmt::Display for Error {
     }
   }
 }
-
-impl From<Error> for wasmrs_frames::PayloadError {
-  fn from(val: Error) -> Self {
-    wasmrs_frames::PayloadError::new(0, val.to_string())
-  }
-}

--- a/crates/wasmrs-runtime/src/runtime.rs
+++ b/crates/wasmrs-runtime/src/runtime.rs
@@ -136,3 +136,44 @@ where
     poll.map_err(|_e| Error::RecvFailed(95))
   }
 }
+
+impl<T> std::fmt::Debug for MutRc<T>
+where
+  T: std::fmt::Debug,
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("MutRc").field(&self.0).finish()
+  }
+}
+
+impl<T> Clone for MutRc<T> {
+  fn clone(&self) -> Self {
+    Self(self.0.clone())
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use anyhow::Result;
+
+  #[test]
+  fn test_mutrc() -> Result<()> {
+    let base = MutRc::new("Hello World".to_owned());
+    let mut lock = base.lock();
+    let res = lock.split_off(6);
+    drop(lock);
+    assert_eq!(res, "World");
+    assert_eq!(base, MutRc::new("Hello ".to_owned()));
+    Ok(())
+  }
+
+  #[test]
+  fn test_rc() -> Result<()> {
+    let one = RtRc::new("Hello World".to_owned());
+    let two = RtRc::new("Hello World".to_owned());
+
+    assert_eq!(one, two);
+    Ok(())
+  }
+}

--- a/crates/wasmrs-runtime/src/runtime/native/mod.rs
+++ b/crates/wasmrs-runtime/src/runtime/native/mod.rs
@@ -134,6 +134,32 @@ impl<T> Clone for OptionalMut<T> {
   }
 }
 
+#[allow(missing_debug_implementations)]
+pub struct MutRc<T>(pub(super) Arc<Mutex<T>>);
+
+impl<T> MutRc<T>
+where
+  T: ConditionallySafe,
+{
+  pub fn new(item: T) -> Self {
+    Self(Arc::new(Mutex::new(item)))
+  }
+
+  pub fn lock(&self) -> parking_lot::lock_api::MutexGuard<'_, parking_lot::RawMutex, T> {
+    self.0.lock()
+  }
+}
+impl<T> PartialEq for MutRc<T>
+where
+  T: PartialEq,
+{
+  fn eq(&self, other: &Self) -> bool {
+    self.0.lock().eq(&other.0.lock())
+  }
+}
+
+pub type RtRc<T> = Arc<T>;
+
 pub trait ConditionallySafe: Send + Sync + 'static {}
 
 impl<S> ConditionallySafe for S where S: Send + Sync + 'static {}

--- a/crates/wasmrs-runtime/src/runtime/wasm/mod.rs
+++ b/crates/wasmrs-runtime/src/runtime/wasm/mod.rs
@@ -2,6 +2,7 @@
 #![allow(missing_docs)]
 
 use std::cell::{RefCell, UnsafeCell};
+use std::rc::Rc;
 use std::sync::Arc;
 
 use futures_util::task::LocalSpawnExt;
@@ -199,6 +200,32 @@ impl<T> Clone for OptionalMut<T> {
     Self(self.0.clone())
   }
 }
+
+#[allow(missing_debug_implementations)]
+pub struct MutRc<T>(pub(super) Rc<RefCell<T>>);
+
+impl<T> MutRc<T>
+where
+  T: ConditionallySafe,
+{
+  pub fn new(item: T) -> Self {
+    Self(Rc::new(RefCell::new(item)))
+  }
+
+  pub fn lock(&self) -> std::cell::RefMut<T> {
+    self.0.borrow_mut()
+  }
+}
+impl<T> PartialEq for MutRc<T>
+where
+  T: PartialEq,
+{
+  fn eq(&self, other: &Self) -> bool {
+    self.0.eq(&other.0)
+  }
+}
+
+pub type RtRc<T> = Rc<T>;
 
 pub trait ConditionallySafe: 'static {}
 

--- a/crates/wasmrs-rx/Cargo.toml
+++ b/crates/wasmrs-rx/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Base host and client implementations of the wasmRS RSocket protocol."
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/crates/wasmrs-rx/Cargo.toml
+++ b/crates/wasmrs-rx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-rx"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Base host and client implementations of the wasmRS RSocket protocol."
@@ -8,7 +8,7 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.4.0" }
+wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.5.0" }
 futures = { workspace = true, default-features = false }
 bytes = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = false }

--- a/crates/wasmrs-rx/README.md
+++ b/crates/wasmrs-rx/README.md
@@ -47,7 +47,7 @@ println!("{}", result);
 A `Flux` is a stream/channel wrapped up together. You can push to it, complete it, and await it:
 
 ```rs
-let mut flux = Flux::<_, Error>::new();
+let mut flux = FluxChannel::<_, Error>::new();
 
 flux.send(100)?;
 flux.send(101)?;
@@ -62,7 +62,7 @@ while let Some(payload) = flux.next().await {
 You can take the receiver portion and split the send/receive as you would other channels:
 
 ```rs
-let flux = Flux::<_, Error>::new();
+let flux = FluxChannel::<_, Error>::new();
 let mut rx = flux.take_rx()?;
 
 let task = tokio::spawn(async move {
@@ -82,7 +82,7 @@ task.await?;
 Since `Flux`es embed the concept of a `Result`, `.send()` pushes `Ok` values and `.error()` can be used to push error values.
 
 ```rs
-let mut flux = Flux::<_, Error>::new();
+let mut flux = FluxChannel::<_, Error>::new();
 
 flux.send(100)?;
 flux.send(101)?;
@@ -97,17 +97,17 @@ while let Some(payload) = flux.next().await {
 
 ## More Info
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
-WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/nanobus/nanobus/blob/main/docs/getting-started.md) for nanobus for up-to-date usage.
+WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/WasmRS/docs/blob/main/wasmrs-rust-howto.md) for usage.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-rx/examples/rx.rs
+++ b/crates/wasmrs-rx/examples/rx.rs
@@ -56,7 +56,7 @@ async fn mono_later() -> Result<()> {
 }
 
 async fn basic_flux() -> Result<()> {
-  let mut flux = Flux::<_, Error>::new();
+  let mut flux = FluxChannel::<_, Error>::new();
 
   flux.send(100)?;
   flux.send(101)?;
@@ -71,7 +71,7 @@ async fn basic_flux() -> Result<()> {
 }
 
 async fn flux_channels() -> Result<()> {
-  let flux = Flux::<_, Error>::new();
+  let flux = FluxChannel::<_, Error>::new();
   let mut rx = flux.take_rx()?;
 
   let task = tokio::spawn(async move {
@@ -91,7 +91,7 @@ async fn flux_channels() -> Result<()> {
 }
 
 async fn errors() -> Result<()> {
-  let mut flux = Flux::<_, Error>::new();
+  let mut flux = FluxChannel::<_, Error>::new();
 
   flux.send(100)?;
   flux.send(101)?;

--- a/crates/wasmrs-rx/src/error.rs
+++ b/crates/wasmrs-rx/src/error.rs
@@ -12,8 +12,6 @@ pub enum Error {
   Runtime(String),
   /// Error decoding a payload.
   Decode(String),
-  /// Missing input in payload.
-  MissingInput(String),
 }
 
 impl std::error::Error for Error {}
@@ -24,11 +22,6 @@ impl std::fmt::Display for Error {
       Error::ReceiverAlreadyGone => f.write_str("Received already taken"),
       Error::Decode(e) => {
         let mut message = "Decode error: ".to_owned();
-        message.push_str(e);
-        f.write_str(e)
-      }
-      Error::MissingInput(e) => {
-        let mut message = "Missing input: ".to_owned();
         message.push_str(e);
         f.write_str(e)
       }

--- a/crates/wasmrs-rx/src/flux/observable.rs
+++ b/crates/wasmrs-rx/src/flux/observable.rs
@@ -1,6 +1,6 @@
 use futures::Stream;
 
-use super::{Flux, FluxPipe};
+use super::{FluxChannel, FluxPipe};
 use wasmrs_runtime::ConditionallySafe;
 
 /// The wasmrs-rx implementation of an Rx Observable trait
@@ -11,7 +11,7 @@ where
   Self: Sized,
 {
   /// Pipe one [Flux] into another.
-  fn pipe(self, into: Flux<Item, Err>) -> FluxPipe<Item, Err, Self> {
+  fn pipe(self, into: FluxChannel<Item, Err>) -> FluxPipe<Item, Err, Self> {
     FluxPipe::new(self, into)
   }
 }

--- a/crates/wasmrs-rx/src/flux/ops/pipe.rs
+++ b/crates/wasmrs-rx/src/flux/ops/pipe.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 use futures::{Stream, TryStreamExt};
 use pin_project_lite::pin_project;
 
-use crate::flux::Flux;
+use crate::flux::FluxChannel;
 use wasmrs_runtime::ConditionallySafe;
 
 pin_project! {
@@ -16,7 +16,7 @@ where
 {
     #[pin]
     from: From,
-    to: Flux<Item, Err>,
+    to: FluxChannel<Item, Err>,
 }
 }
 
@@ -26,7 +26,7 @@ where
   Err: ConditionallySafe,
 {
   /// Create a new [FluxPipe]
-  pub fn new(from: From, to: Flux<Item, Err>) -> Self {
+  pub fn new(from: From, to: FluxChannel<Item, Err>) -> Self {
     Self { from, to }
   }
 }
@@ -63,11 +63,11 @@ mod test {
 
   #[tokio::test]
   async fn test_pipes() -> Result<()> {
-    let (flux, observer) = Flux::new_channels();
+    let (flux, observer) = FluxChannel::new_parts();
 
     flux.send("First".to_owned())?;
 
-    let second_flux = Flux::<String, String>::new();
+    let second_flux = FluxChannel::<String, String>::new();
 
     let mut pipe = observer.pipe(second_flux);
 

--- a/crates/wasmrs-rx/src/flux/receiver.rs
+++ b/crates/wasmrs-rx/src/flux/receiver.rs
@@ -4,7 +4,7 @@ use std::{io::Write, pin::Pin};
 use futures::Stream;
 
 use super::{signal_into_result, FutureResult, Signal};
-use crate::{Error, Observable};
+use crate::{Error, FluxChannel, Observable, Observer};
 use wasmrs_runtime::{ConditionallySafe, OptionalMut, UnboundedReceiver};
 
 #[must_use]
@@ -35,6 +35,17 @@ where
     Self {
       rx: OptionalMut::none(),
     }
+  }
+
+  /// Create a new [FluxReceiver] that is immediately closed with the passed item.
+  pub fn one<I, E>(item: Result<I, E>) -> FluxReceiver<I, E>
+  where
+    I: ConditionallySafe,
+    E: ConditionallySafe,
+  {
+    let (tx, rx) = FluxChannel::new_parts();
+    tx.send_result(item).unwrap();
+    rx
   }
 }
 

--- a/crates/wasmrs-rx/src/flux/signal.rs
+++ b/crates/wasmrs-rx/src/flux/signal.rs
@@ -24,7 +24,7 @@ where
     match self {
       Self::Ok(arg0) => f.debug_tuple("Ok").field(arg0).finish(),
       Self::Err(arg0) => f.debug_tuple("Err").field(arg0).finish(),
-      Self::Complete => write!(f, "Complete"),
+      Self::Complete => f.write_str("Complete"),
     }
   }
 }

--- a/crates/wasmrs-testhost/Cargo.toml
+++ b/crates/wasmrs-testhost/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Wasmtime engine for wasmRS hosts"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/crates/wasmrs-testhost/Cargo.toml
+++ b/crates/wasmrs-testhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-testhost"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Wasmtime engine for wasmRS hosts"
@@ -12,8 +12,8 @@ default = []
 profiler = []
 
 [dependencies]
-wasmrs-host = { path = "../wasmrs-host", version = "0.4.0" }
-wasmrs = { path = "../wasmrs", version = "0.4.0" }
+wasmrs-host = { path = "../wasmrs-host", version = "0.5.0" }
+wasmrs = { path = "../wasmrs", version = "0.5.0" }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
@@ -32,9 +32,9 @@ serde_json = "1.0"
 [dev-dependencies]
 env_logger = { workspace = true }
 wasmrs = { path = "../wasmrs" }
-wasmrs-frames = { path = "../wasmrs-frames", version = "0.4.0" }
-wasmrs-rx = { path = "../wasmrs-rx", version = "0.4.0" }
-wasmrs-codec = { path = "../wasmrs-codec", version = "0.4.1" }
+wasmrs-frames = { path = "../wasmrs-frames", version = "0.5.0" }
+wasmrs-rx = { path = "../wasmrs-rx", version = "0.5.0" }
+wasmrs-codec = { path = "../wasmrs-codec", version = "0.5.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 test-log = "0.2.10"
 serde = { workspace = true }

--- a/crates/wasmrs-testhost/README.md
+++ b/crates/wasmrs-testhost/README.md
@@ -8,11 +8,11 @@ This crate is a low-level API for testing wasmRS modules. It is not intended for
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-testhost/src/store.rs
+++ b/crates/wasmrs-testhost/src/store.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use parking_lot::Mutex;
-use wasmrs::{BufferState, Frame, OperationList, WasmSocket};
+use wasmrs::{BufferState, Frame, OperationList, PayloadError, WasmSocket};
 use wasmrs_host::errors::Error;
 use wasmrs_host::{CallbackProvider, WasiParams};
 use wasmtime::{Engine, Store};
@@ -33,7 +33,9 @@ impl CallbackProvider for ProviderStore {
         Ok(())
       }
       Err((stream_id, err)) => {
-        self.socket.send(Frame::new_error(stream_id, 0, err.to_string()));
+        self
+          .socket
+          .send(Frame::new_error(stream_id, PayloadError::new(0, err.to_string(), None)));
         Ok(())
       }
     }

--- a/crates/wasmrs-testhost/tests/replays.rs
+++ b/crates/wasmrs-testhost/tests/replays.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use base64::Engine;
-use wasmrs::{Payload, RSocket, SocketSide, WasmSocket};
+use wasmrs::{RSocket, RawPayload, SocketSide, WasmSocket};
 use wasmrs_frames::PayloadError;
 use wasmrs_host::WasiParams;
 use wasmrs_rx::*;
@@ -62,22 +62,22 @@ async fn test_iota_req_channel() -> anyhow::Result<()> {
 struct HostServer {}
 
 impl RSocket for HostServer {
-  fn fire_and_forget(&self, _req: Payload) -> Mono<(), PayloadError> {
+  fn fire_and_forget(&self, _req: RawPayload) -> Mono<(), PayloadError> {
     Mono::default()
   }
 
-  fn request_response(&self, _payload: Payload) -> Mono<Payload, PayloadError> {
+  fn request_response(&self, _payload: RawPayload) -> Mono<RawPayload, PayloadError> {
     Mono::default()
   }
 
-  fn request_stream(&self, _req: Payload) -> FluxReceiver<Payload, PayloadError> {
-    let (tx, rx) = Flux::new_channels();
+  fn request_stream(&self, _req: RawPayload) -> FluxReceiver<RawPayload, PayloadError> {
+    let (tx, rx) = FluxChannel::new_parts();
     tx.complete();
     rx
   }
 
-  fn request_channel(&self, _reqs: FluxReceiver<Payload, PayloadError>) -> FluxReceiver<Payload, PayloadError> {
-    let (tx, rx) = Flux::new_channels();
+  fn request_channel(&self, _reqs: Box<dyn Flux<RawPayload, PayloadError>>) -> FluxReceiver<RawPayload, PayloadError> {
+    let (tx, rx) = FluxChannel::new_parts();
     tx.complete();
     rx
   }

--- a/crates/wasmrs-wasmtime/Cargo.toml
+++ b/crates/wasmrs-wasmtime/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Wasmtime engine for wasmRS hosts"
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/crates/wasmrs-wasmtime/Cargo.toml
+++ b/crates/wasmrs-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs-wasmtime"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Wasmtime engine for wasmRS hosts"
@@ -12,8 +12,8 @@ default = []
 profiler = []
 
 [dependencies]
-wasmrs-host = { path = "../wasmrs-host", version = "0.4.0" }
-wasmrs = { path = "../wasmrs", version = "0.4.0" }
+wasmrs-host = { path = "../wasmrs-host", version = "0.5.0" }
+wasmrs = { path = "../wasmrs", version = "0.5.0" }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
@@ -28,8 +28,8 @@ anyhow = { version = "1.0" }
 
 [dev-dependencies]
 env_logger = { workspace = true }
-wasmrs-rx = { path = "../wasmrs-rx", version = "0.4.0" }
-wasmrs-codec = { path = "../wasmrs-codec", version = "0.4.1" }
+wasmrs-rx = { path = "../wasmrs-rx", version = "0.5.0" }
+wasmrs-codec = { path = "../wasmrs-codec", version = "0.5.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 test-log = "0.2.10"
 serde = { workspace = true }

--- a/crates/wasmrs-wasmtime/README.md
+++ b/crates/wasmrs-wasmtime/README.md
@@ -4,17 +4,17 @@ This crate provides the wasmtime implementation for wasmrs hosts.
 
 ## Usage
 
-See the [example](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs-wasmtime/examples/request.rs) for usage.
+See the [example](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs-wasmtime/examples/request.rs) for usage.
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs-wasmtime/examples/request.rs
+++ b/crates/wasmrs-wasmtime/examples/request.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use wasmrs::{Metadata, Payload, RSocket};
+use wasmrs::{Metadata, RSocket, RawPayload};
 use wasmrs_codec::messagepack::*;
 use wasmrs_host::WasiParams;
 use wasmrs_wasmtime::WasmtimeBuilder;
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
   let val: serde_json::Value = serde_json::from_str(&args.data)?;
   let bytes = serialize(&val).unwrap();
 
-  let payload = Payload::new(mbytes, bytes.into());
+  let payload = RawPayload::new(mbytes, bytes.into());
 
   if args.stream {
     unimplemented!()

--- a/crates/wasmrs-wasmtime/src/store.rs
+++ b/crates/wasmrs-wasmtime/src/store.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use parking_lot::Mutex;
-use wasmrs::{BufferState, Frame, OperationList, WasmSocket};
+use wasmrs::{BufferState, Frame, OperationList, PayloadError, WasmSocket};
 use wasmrs_host::errors::Error;
 use wasmrs_host::{CallbackProvider, WasiParams};
 use wasmtime::{Engine, Store};
@@ -33,7 +33,9 @@ impl CallbackProvider for ProviderStore {
         .process_once(frame)
         .map_err(|e| Error::SendFailed(e.to_string())),
       Err((stream_id, err)) => {
-        self.socket.send(Frame::new_error(stream_id, 0, err.to_string()));
+        self
+          .socket
+          .send(Frame::new_error(stream_id, PayloadError::new(0, err.to_string(), None)));
         Ok(())
       }
     }

--- a/crates/wasmrs-wasmtime/tests/request_response.rs
+++ b/crates/wasmrs-wasmtime/tests/request_response.rs
@@ -1,4 +1,4 @@
-use wasmrs::{Metadata, Payload, RSocket};
+use wasmrs::{Metadata, RSocket, RawPayload};
 use wasmrs_codec::messagepack::*;
 use wasmrs_host::WasiParams;
 use wasmrs_wasmtime::WasmtimeBuilder;
@@ -26,7 +26,7 @@ async fn test_iota_req_response() -> anyhow::Result<()> {
 
   let bytes = serialize(&input).unwrap();
 
-  let payload = Payload::new(mbytes, bytes.into());
+  let payload = RawPayload::new(mbytes, bytes.into());
 
   let response = context.request_response(payload.clone());
   match response.await {

--- a/crates/wasmrs-wasmtime/tests/request_stream.rs
+++ b/crates/wasmrs-wasmtime/tests/request_stream.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use futures::StreamExt;
-use wasmrs::{Metadata, Payload, RSocket};
+use wasmrs::{Metadata, RSocket, RawPayload};
 use wasmrs_codec::messagepack::*;
 use wasmrs_host::WasiParams;
 use wasmrs_wasmtime::WasmtimeBuilder;
@@ -29,7 +29,7 @@ async fn test_iota_req_stream() -> anyhow::Result<()> {
 
   let bytes = serialize(&input).unwrap();
 
-  let payload = Payload::new(mbytes, bytes.into());
+  let payload = RawPayload::new(mbytes, bytes.into());
 
   let mut response = context.request_stream(payload.clone());
   let mut outputs: VecDeque<String> = input.input.chars().map(|i| i.to_string()).collect();

--- a/crates/wasmrs-wasmtime/tests/test_callback.rs
+++ b/crates/wasmrs-wasmtime/tests/test_callback.rs
@@ -1,0 +1,67 @@
+use std::collections::VecDeque;
+
+use futures::StreamExt;
+use wasmrs::{GenericError, Metadata, Payload, PayloadError, RSocket, RawPayload};
+use wasmrs_codec::messagepack::*;
+use wasmrs_host::WasiParams;
+use wasmrs_rx::*;
+use wasmrs_wasmtime::WasmtimeBuilder;
+
+static MODULE_BYTES: &[u8] = include_bytes!("../../../build/baseline.wasm");
+
+fn callback(
+  incoming: FluxReceiver<Payload, PayloadError>,
+) -> Result<FluxReceiver<RawPayload, PayloadError>, GenericError> {
+  let (tx, rx) = FluxChannel::new_parts();
+  tokio::spawn(async move {
+    let mut incoming = incoming;
+    while let Some(payload) = incoming.next().await {
+      let _ = tx.send_result(payload.map(|p| RawPayload::new_data(None, Some(p.data))));
+    }
+  });
+  Ok(rx)
+}
+
+#[test_log::test(tokio::test)]
+async fn test_iota_req_channel_callback() -> anyhow::Result<()> {
+  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+    .wasi_params(WasiParams::default())
+    .build()?;
+  let host = wasmrs_host::Host::new(engine)?;
+
+  host.register_request_channel("test", "callback", callback);
+  let context = host.new_context()?;
+  let op = context.get_export("test", "callback")?;
+
+  let mbytes = Metadata::new(op).encode();
+
+  let input = "HELLO WORLD".to_owned();
+
+  let bytes = serialize(&input).unwrap();
+
+  let payload = RawPayload::new(mbytes, bytes.into());
+
+  let stream = FluxChannel::new();
+  stream.send(payload.clone())?;
+  stream.complete();
+  let mut response = context.request_channel(Box::new(stream));
+  let mut outputs: VecDeque<String> = vec!["HELLO WORLD".to_owned()].into();
+  while let Some(response) = response.next().await {
+    println!("response: {:?}", response);
+    match response {
+      Ok(v) => {
+        let bytes = v.data.unwrap();
+        let val: String = deserialize(&bytes).unwrap();
+        println!("{}", val);
+        let next = outputs.pop_front().unwrap();
+        assert_eq!(val, next);
+      }
+      Err(e) => {
+        panic!("Error: {:?}", e);
+      }
+    }
+  }
+  assert!(outputs.is_empty());
+
+  Ok(())
+}

--- a/crates/wasmrs/Cargo.toml
+++ b/crates/wasmrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmrs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Base host and client implementations of the wasmRS RSocket protocol."
@@ -20,10 +20,10 @@ print-frames = ["record-frames"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-wasmrs-frames = { path = "../wasmrs-frames", version = "0.4.0" }
-wasmrs-codec = { path = "../wasmrs-codec", version = "0.4.1" }
-wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.4.0" }
-wasmrs-rx = { path = "../wasmrs-rx", version = "0.4.0" }
+wasmrs-frames = { path = "../wasmrs-frames", version = "0.5.0" }
+wasmrs-codec = { path = "../wasmrs-codec", version = "0.5.0" }
+wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.5.0" }
+wasmrs-rx = { path = "../wasmrs-rx", version = "0.5.0" }
 futures = { workspace = true, default-features = false }
 bytes = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = false }

--- a/crates/wasmrs/Cargo.toml
+++ b/crates/wasmrs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Base host and client implementations of the wasmRS RSocket protocol."
-repository = "https://github.com/nanobus/iota"
+repository = "https://github.com/wasmrs/wasmrs-rust"
 
 [features]
 default = []

--- a/crates/wasmrs/README.md
+++ b/crates/wasmrs/README.md
@@ -6,21 +6,21 @@ The `wasmrs` crate is the base implementation of the bidirectional WebAssembly s
 
 ## Usage
 
-See [wasmrs-guest](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs-guest/README.md), [wasmrs-host](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs-guest/README.md), and [wasmrs-wamtime](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs-guest/README.md) for examples on how to use wasmrs directly.
+See [wasmrs-guest](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs-guest/README.md), [wasmrs-host](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs-guest/README.md), and [wasmrs-wamtime](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs-guest/README.md) for examples on how to use wasmrs directly.
 
 ## More Information
 
-For more information on wasmRS, see the core [wasmrs](https://github.com/nanobus/iota/blob/main/rust/crates/wasmrs/README.md) crate.
+For more information on wasmRS, see the core [wasmrs](https://github.com/wasmrs/wasmrs-rust/blob/main/crates/wasmrs/README.md) crate.
 
-WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/nanobus/nanobus/blob/main/docs/getting-started.md) for nanobus for up-to-date usage.
+WasmRS makes heavy use of generated code from `apex` specs and generators to automate all of the boilerplate. See the [getting-started](https://github.com/WasmRS/docs/blob/main/wasmrs-rust-howto.md) for usage.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/nanobus/iota/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/WasmRS/wasmrs-rust/blob/main/CONTRIBUTING.md)
 
 ## License
 
-See the root [LICENSE.txt](https://github.com/nanobus/iota/blob/main/LICENSE.txt)
+See the root [LICENSE.txt](https://github.com/WasmRS/wasmrs-rust/blob/main/LICENSE.txt)
 
 
 

--- a/crates/wasmrs/src/handlers.rs
+++ b/crates/wasmrs/src/handlers.rs
@@ -1,0 +1,165 @@
+use bytes::Bytes;
+use wasmrs_frames::{Metadata, PayloadError, RawPayload};
+use wasmrs_runtime::RtRc;
+use wasmrs_rx::{FluxReceiver, Mono};
+
+use crate::operations::OperationList;
+
+/// An alias to [Box<dyn std::error::Error + Send + Sync + 'static>]
+pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
+/// An alias for a [Vec<(String, String, RtRc<T>)>]
+pub type OperationMap<T> = Vec<(String, String, RtRc<T>)>;
+/// An alias for the function that creates the output for a task.
+pub type ProcessFactory<I, O> = fn(I) -> Result<O, GenericError>;
+
+/// An alias for [Mono<ParsedPayload, PayloadError>]
+pub type IncomingMono = Mono<Payload, PayloadError>;
+/// An alias for [Mono<Payload, PayloadError>]
+pub type OutgoingMono = Mono<RawPayload, PayloadError>;
+/// An alias for [FluxReceiver<ParsedPayload, PayloadError>]
+pub type IncomingStream = FluxReceiver<Payload, PayloadError>;
+/// An alias for [FluxReceiver<Payload, PayloadError>]
+pub type OutgoingStream = FluxReceiver<RawPayload, PayloadError>;
+
+#[allow(missing_debug_implementations)]
+#[derive(Debug)]
+/// A [Payload] with pre-parsed [Metadata].
+pub struct Payload {
+  /// The parsed [Metadata].
+  pub metadata: Metadata,
+  /// The raw data bytes.
+  pub data: Bytes,
+}
+
+impl Payload {
+  /// Create a new [ParsedPayload] from the given [Metadata] and [Bytes].
+  pub fn new(metadata: Metadata, data: Bytes) -> Self {
+    Self { metadata, data }
+  }
+}
+
+impl TryFrom<RawPayload> for Payload {
+  type Error = crate::Error;
+
+  fn try_from(mut value: RawPayload) -> Result<Self, Self::Error> {
+    Ok(Payload {
+      metadata: value.parse_metadata()?,
+      data: value.data.unwrap_or_default(),
+    })
+  }
+}
+
+#[derive(Default)]
+/// A list of all the operations exported by a wasmrs implementer.
+pub struct Handlers {
+  op_list: OperationList,
+  request_response_handlers: OperationMap<ProcessFactory<IncomingMono, OutgoingMono>>,
+  request_stream_handlers: OperationMap<ProcessFactory<IncomingMono, OutgoingStream>>,
+  request_channel_handlers: OperationMap<ProcessFactory<IncomingStream, OutgoingStream>>,
+  request_fnf_handlers: OperationMap<ProcessFactory<IncomingMono, ()>>,
+}
+
+impl std::fmt::Debug for Handlers {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("Handlers").field("op_list", &self.op_list).finish()
+  }
+}
+
+impl Handlers {
+  /// Register a Request/Response style handler on the host.
+  pub fn register_request_response(
+    &mut self,
+    ns: impl AsRef<str>,
+    op: impl AsRef<str>,
+    handler: ProcessFactory<IncomingMono, OutgoingMono>,
+  ) {
+    let list = &mut self.request_response_handlers;
+    list.push((ns.as_ref().to_owned(), op.as_ref().to_owned(), RtRc::new(handler)));
+    let index = list.len() - 1;
+    self
+      .op_list
+      .add_export(index as _, crate::OperationType::RequestFnF, ns, op);
+  }
+
+  /// Register a Request/Response style handler on the host.
+  pub fn register_request_stream(
+    &mut self,
+    ns: impl AsRef<str>,
+    op: impl AsRef<str>,
+    handler: ProcessFactory<IncomingMono, OutgoingStream>,
+  ) {
+    let list = &mut self.request_stream_handlers;
+    list.push((ns.as_ref().to_owned(), op.as_ref().to_owned(), RtRc::new(handler)));
+    let index = list.len() - 1;
+    self
+      .op_list
+      .add_export(index as _, crate::OperationType::RequestFnF, ns, op);
+  }
+
+  /// Register a Request/Response style handler on the host.
+  pub fn register_request_channel(
+    &mut self,
+    ns: impl AsRef<str>,
+    op: impl AsRef<str>,
+    handler: ProcessFactory<IncomingStream, OutgoingStream>,
+  ) {
+    let list = &mut self.request_channel_handlers;
+    list.push((ns.as_ref().to_owned(), op.as_ref().to_owned(), RtRc::new(handler)));
+    let index = list.len() - 1;
+    self
+      .op_list
+      .add_export(index as _, crate::OperationType::RequestFnF, ns, op);
+  }
+
+  /// Register a Request/Response style handler on the host.
+  pub fn register_fire_and_forget(
+    &mut self,
+    ns: impl AsRef<str>,
+    op: impl AsRef<str>,
+    handler: ProcessFactory<IncomingMono, ()>,
+  ) {
+    let list = &mut self.request_fnf_handlers;
+    list.push((ns.as_ref().to_owned(), op.as_ref().to_owned(), RtRc::new(handler)));
+    let index = list.len() - 1;
+    self
+      .op_list
+      .add_export(index as _, crate::OperationType::RequestFnF, ns, op);
+  }
+
+  #[must_use]
+  /// Get a Request/Response handler by id.
+  pub fn get_request_response_handler(&self, index: u32) -> Option<RtRc<ProcessFactory<IncomingMono, OutgoingMono>>> {
+    let a = self
+      .request_response_handlers
+      .get(index as usize)
+      .map(|(_, _, h)| h.clone());
+    a
+  }
+  #[must_use]
+  /// Get a Request/Response handler by id.
+  pub fn get_request_stream_handler(&self, index: u32) -> Option<RtRc<ProcessFactory<IncomingMono, OutgoingStream>>> {
+    let a = self
+      .request_stream_handlers
+      .get(index as usize)
+      .map(|(_, _, h)| h.clone());
+    a
+  }
+  #[must_use]
+  /// Get a Request/Response handler by id.
+  pub fn get_request_channel_handler(
+    &self,
+    index: u32,
+  ) -> Option<RtRc<ProcessFactory<IncomingStream, OutgoingStream>>> {
+    let a = self
+      .request_channel_handlers
+      .get(index as usize)
+      .map(|(_, _, h)| h.clone());
+    a
+  }
+  #[must_use]
+  /// Get a Request/Response handler by id.
+  pub fn get_fnf_handler(&self, index: u32) -> Option<RtRc<ProcessFactory<IncomingMono, ()>>> {
+    let a = self.request_fnf_handlers.get(index as usize).map(|(_, _, h)| h.clone());
+    a
+  }
+}

--- a/crates/wasmrs/src/operations.rs
+++ b/crates/wasmrs/src/operations.rs
@@ -124,6 +124,12 @@ impl OperationList {
     Self::get_op(&self.exports, namespace, operation)
   }
 
+  #[must_use]
+  /// Get a list of the exports by name.
+  pub fn get_exports(&self) -> Vec<String> {
+    self.exports.iter().map(|op| op.operation.clone()).collect()
+  }
+
   fn get_op(list: &[Operation], namespace: &str, operation: &str) -> Option<u32> {
     list
       .iter()

--- a/crates/wasmrs/src/record.rs
+++ b/crates/wasmrs/src/record.rs
@@ -108,14 +108,15 @@ impl FrameRecord {
 
 impl std::fmt::Display for FrameRecord {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      FrameRecord::Incoming { side, stream_id, frame } => {
-        write!(f, "s{}-{}-in", stream_id, side)
-      }
-      FrameRecord::Outgoing { side, stream_id, frame } => {
-        write!(f, "s{}-{}-out", stream_id, side)
-      }
-    }
+    let (sid, side) = match self {
+      FrameRecord::Incoming { side, stream_id, frame } => (stream_id, side),
+      FrameRecord::Outgoing { side, stream_id, frame } => (stream_id, side),
+    };
+    f.write_str("s")?;
+    sid.fmt(f)?;
+    f.write_str("-")?;
+    side.fmt(f)?;
+    f.write_str("-out")
   }
 }
 

--- a/crates/wasmrs/src/socket/responder.rs
+++ b/crates/wasmrs/src/socket/responder.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use wasmrs_rx::*;
 
-use crate::{Mono, Payload, PayloadError, RSocket};
+use crate::{Mono, PayloadError, RSocket, RawPayload};
 
 #[derive(Clone)]
 pub(crate) struct Responder {
@@ -19,23 +19,23 @@ impl Responder {
 }
 
 impl RSocket for Responder {
-  fn fire_and_forget(&self, req: Payload) -> Mono<(), PayloadError> {
+  fn fire_and_forget(&self, req: RawPayload) -> Mono<(), PayloadError> {
     let inner = self.inner.read();
     (*inner).fire_and_forget(req)
   }
 
-  fn request_response(&self, req: Payload) -> Mono<Payload, PayloadError> {
+  fn request_response(&self, req: RawPayload) -> Mono<RawPayload, PayloadError> {
     let inner = self.inner.read();
     (*inner).request_response(req)
   }
 
-  fn request_stream(&self, req: Payload) -> FluxReceiver<Payload, PayloadError> {
+  fn request_stream(&self, req: RawPayload) -> FluxReceiver<RawPayload, PayloadError> {
     let inner = self.inner.clone();
     let r = inner.read();
     (*r).request_stream(req)
   }
 
-  fn request_channel(&self, stream: FluxReceiver<Payload, PayloadError>) -> FluxReceiver<Payload, PayloadError> {
+  fn request_channel(&self, stream: Box<dyn Flux<RawPayload, PayloadError>>) -> FluxReceiver<RawPayload, PayloadError> {
     let inner = self.inner.clone();
     let r = inner.read();
     (*r).request_channel(stream)
@@ -44,23 +44,23 @@ impl RSocket for Responder {
 pub(crate) struct EmptyRSocket;
 
 impl RSocket for EmptyRSocket {
-  fn fire_and_forget(&self, _req: Payload) -> Mono<(), PayloadError> {
-    Mono::new_error(PayloadError::application_error("Unimplemented"))
+  fn fire_and_forget(&self, _req: RawPayload) -> Mono<(), PayloadError> {
+    Mono::new_error(PayloadError::application_error("Unimplemented", None))
   }
 
-  fn request_response(&self, _req: Payload) -> Mono<Payload, PayloadError> {
-    Mono::new_error(PayloadError::application_error("Unimplemented"))
+  fn request_response(&self, _req: RawPayload) -> Mono<RawPayload, PayloadError> {
+    Mono::new_error(PayloadError::application_error("Unimplemented", None))
   }
 
-  fn request_stream(&self, _req: Payload) -> FluxReceiver<Payload, PayloadError> {
-    let channel = Flux::<Payload, PayloadError>::new();
-    let _ = channel.error(PayloadError::application_error("Unimplemented"));
-    channel.take_rx().unwrap()
+  fn request_stream(&self, _req: RawPayload) -> FluxReceiver<RawPayload, PayloadError> {
+    let (tx, channel) = FluxChannel::<RawPayload, PayloadError>::new_parts();
+    let _ = tx.error(PayloadError::application_error("Unimplemented", None));
+    channel
   }
 
-  fn request_channel(&self, _reqs: FluxReceiver<Payload, PayloadError>) -> FluxReceiver<Payload, PayloadError> {
-    let channel = Flux::<Payload, PayloadError>::new();
-    let _ = channel.error(PayloadError::application_error("Unimplemented"));
-    channel.take_rx().unwrap()
+  fn request_channel(&self, _reqs: Box<dyn Flux<RawPayload, PayloadError>>) -> FluxReceiver<RawPayload, PayloadError> {
+    let (tx, channel) = FluxChannel::<RawPayload, PayloadError>::new_parts();
+    let _ = tx.error(PayloadError::application_error("Unimplemented", None));
+    channel
   }
 }

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ debug:
 
 test:
   cargo test --workspace
+  cargo test -p wasmrs-runtime --target=wasm32-unknown-unknown
 
 clean:
   cargo clean

--- a/wasm/baseline/Cargo.lock
+++ b/wasm/baseline/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-codec"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "heapless",
  "serde",
@@ -543,14 +543,14 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-frames"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
 name = "wasmrs-guest"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-rx"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/wasm/baseline/src/lib.rs
+++ b/wasm/baseline/src/lib.rs
@@ -8,36 +8,37 @@ extern "C" fn __wasmrs_init(guest_buffer_size: u32, host_buffer_size: u32, max_h
   guest::register_request_response("greeting", "sayHello", request_response);
   guest::register_request_stream("echo", "chars", request_stream);
   guest::register_request_channel("echo", "reverse", request_channel);
+  guest::register_request_channel("test", "callback", channel_callback);
+  guest::add_import(0, OperationType::RequestChannel, "test", "echo");
 }
 
-fn request_response(input: Mono<ParsedPayload, PayloadError>) -> Result<Mono<Payload, PayloadError>, GenericError> {
+fn request_response(input: Mono<Payload, PayloadError>) -> Result<Mono<RawPayload, PayloadError>, GenericError> {
   Ok(Mono::from_future(async move {
     let input = deserialize::<String>(&input.await.unwrap().data).unwrap();
     let output = format!("Hello, {}!", input);
-    Ok(Payload::new_data(None, Some(serialize(&output).unwrap().into())))
+    Ok(RawPayload::new_data(None, Some(serialize(&output).unwrap().into())))
   }))
 }
 
-fn request_stream(
-  input: Mono<ParsedPayload, PayloadError>,
-) -> Result<FluxReceiver<Payload, PayloadError>, GenericError> {
-  let channel = Flux::<Payload, PayloadError>::new();
+fn request_stream(input: Mono<Payload, PayloadError>) -> Result<FluxReceiver<RawPayload, PayloadError>, GenericError> {
+  let channel = FluxChannel::<RawPayload, PayloadError>::new();
   let rx = channel.take_rx().unwrap();
   spawn(async move {
     let input = deserialize::<String>(&input.await.unwrap().data).unwrap();
     for char in input.chars() {
       channel
-        .send(Payload::new_data(None, Some(serialize(&char).unwrap().into())))
+        .send(RawPayload::new_data(None, Some(serialize(&char).unwrap().into())))
         .unwrap();
     }
   });
 
   Ok(rx)
 }
+
 fn request_channel(
-  mut input: FluxReceiver<ParsedPayload, PayloadError>,
-) -> Result<FluxReceiver<Payload, PayloadError>, GenericError> {
-  let channel = Flux::<Payload, PayloadError>::new();
+  mut input: FluxReceiver<Payload, PayloadError>,
+) -> Result<FluxReceiver<RawPayload, PayloadError>, GenericError> {
+  let channel = FluxChannel::<RawPayload, PayloadError>::new();
   let rx = channel.take_rx().unwrap();
   spawn(async move {
     while let Some(payload) = input.next().await {
@@ -48,11 +49,51 @@ fn request_channel(
       let payload = payload.unwrap();
       let input = deserialize::<String>(&payload.data).unwrap();
       let output: String = input.chars().rev().collect();
-      if let Err(e) = channel.send(Payload::new_data(None, Some(serialize(&output).unwrap().into()))) {
+      if let Err(e) = channel.send(RawPayload::new_data(None, Some(serialize(&output).unwrap().into()))) {
         println!("{}", e);
       }
     }
   });
 
   Ok(rx)
+}
+
+fn channel_callback(
+  mut input: FluxReceiver<Payload, PayloadError>,
+) -> Result<FluxReceiver<RawPayload, PayloadError>, GenericError> {
+  let (job_tx, job_rx) = FluxChannel::<RawPayload, PayloadError>::new_parts();
+  let (host_tx, host_rx) = FluxChannel::<RawPayload, PayloadError>::new_parts();
+  let mut host_stream = Host::default().request_channel(Box::new(host_rx));
+  spawn(async move {
+    println!("waiting for input...");
+    while let Some(payload) = input.next().await {
+      if let Err(e) = payload {
+        println!("{}", e);
+        continue;
+      }
+      let payload = payload.unwrap();
+      println!("got payload: {:?}", payload);
+      let input = deserialize::<String>(&payload.data).unwrap();
+      let md = Metadata::new(0);
+      host_tx
+        .send(RawPayload::new_data(
+          Some(md.encode()),
+          Some(serialize(&input).unwrap().into()),
+        ))
+        .unwrap();
+    }
+  });
+  spawn(async move {
+    println!("waiting for host output...");
+    while let Some(Ok(payload)) = host_stream.next().await {
+      let output = deserialize::<String>(&payload.data.unwrap()).unwrap();
+
+      println!("sending final output...");
+      job_tx
+        .send(RawPayload::new_data(None, Some(serialize(&output).unwrap().into())))
+        .unwrap();
+    }
+  });
+
+  Ok(job_rx)
 }

--- a/wasm/grabbag/Cargo.lock
+++ b/wasm/grabbag/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-codec"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "heapless",
  "serde",

--- a/wasm/grabbag/apex.yaml
+++ b/wasm/grabbag/apex.yaml
@@ -2,4 +2,4 @@ spec: ./apex.axdl
 config:
   name: 'reqres-component'
 plugins:
-  - '../../../wasmrs-codegen/src/rust/plugin.ts'
+  - 'https://raw.githubusercontent.com/WasmRS/codegen/main/src/rust/plugin.ts'

--- a/wasm/grabbag/apex.yaml
+++ b/wasm/grabbag/apex.yaml
@@ -2,4 +2,4 @@ spec: ./apex.axdl
 config:
   name: 'reqres-component'
 plugins:
-  - '../../../codegen/src/rust/plugin.ts'
+  - '../../../wasmrs-codegen/src/rust/plugin.ts'

--- a/wasm/grabbag/src/actions/mod.rs
+++ b/wasm/grabbag/src/actions/mod.rs
@@ -104,15 +104,15 @@ extern "C" fn __wasmrs_init(guest_buffer_size: u32, host_buffer_size: u32, max_h
 }
 
 fn deserialize_helper(
-  i: Mono<ParsedPayload, PayloadError>,
+  i: Mono<Payload, PayloadError>,
 ) -> Mono<std::collections::BTreeMap<String, wasmrs_guest::Value>, PayloadError> {
   Mono::from_future(async move {
     match i.await {
       Ok(bytes) => match deserialize(&bytes.data) {
         Ok(v) => Ok(v),
-        Err(e) => Err(PayloadError::application_error(e.to_string())),
+        Err(e) => Err(PayloadError::application_error(e.to_string(), None)),
       },
-      Err(e) => Err(PayloadError::application_error(e.to_string())),
+      Err(e) => Err(PayloadError::application_error(e.to_string(), None)),
     }
   })
 }
@@ -125,7 +125,7 @@ pub(crate) struct MyStreamerComponent();
 
 impl MyStreamerComponent {
   fn request_stream_i64_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -143,7 +143,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -152,8 +152,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -161,14 +161,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_f64_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -186,7 +186,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -195,8 +195,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -204,14 +204,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_type_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -229,7 +229,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -238,8 +238,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -247,14 +247,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_enum_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -272,7 +272,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -281,8 +281,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -290,14 +290,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_uuid_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -315,7 +315,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -324,8 +324,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -333,14 +333,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_alias_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -358,7 +358,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -367,8 +367,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -376,14 +376,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_string_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -401,7 +401,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -410,8 +410,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -419,14 +419,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_bool_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -444,7 +444,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -453,8 +453,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -462,14 +462,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_datetime_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -487,7 +487,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -496,8 +496,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -505,14 +505,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_list_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -530,7 +530,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -539,8 +539,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -548,14 +548,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_map_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -573,7 +573,7 @@ impl MyStreamerComponent {
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -582,8 +582,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -591,14 +591,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_i64_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -617,13 +617,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -632,8 +632,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -641,14 +641,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_f64_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -667,13 +667,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -682,8 +682,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -691,14 +691,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_type_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -717,13 +717,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -732,8 +732,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -741,14 +741,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_enum_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -767,13 +767,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -782,8 +782,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -791,14 +791,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_uuid_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -817,13 +817,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -832,8 +832,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -841,14 +841,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_alias_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -867,13 +867,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -882,8 +882,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -891,14 +891,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_string_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -917,13 +917,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -932,8 +932,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -941,14 +941,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_bool_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -967,13 +967,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -982,8 +982,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -991,14 +991,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_datetime_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -1017,13 +1017,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -1032,8 +1032,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -1041,14 +1041,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_list_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -1067,13 +1067,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -1082,8 +1082,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -1091,14 +1091,14 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_stream_args_map_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
-    let (out_tx, out_rx) = Flux::new_channels();
+    let (out_tx, out_rx) = FluxChannel::new_parts();
     let input = deserialize_helper(input);
     spawn(async move {
       let input_payload = match input.await {
@@ -1117,13 +1117,13 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let input = match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
       };
@@ -1132,8 +1132,8 @@ impl MyStreamerComponent {
           while let Some(next) = result.next().await {
             let out = match next {
               Ok(output) => serialize(&output)
-                .map(|b| Payload::new_data(None, Some(b.into())))
-                .map_err(|e| PayloadError::application_error(e.to_string())),
+                .map(|b| RawPayload::new_data(None, Some(b.into())))
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
               Err(e) => Err(e),
             };
             let _ = out_tx.send_result(out);
@@ -1141,24 +1141,25 @@ impl MyStreamerComponent {
           out_tx.complete();
         }
         Err(e) => {
-          let _ = out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = out_tx.error(PayloadError::application_error(e.to_string(), None));
         }
       }
     });
     Ok(out_rx)
   }
   fn request_channel_i64_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_i64::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_i64::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_i64::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <i64 as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <i64 as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1170,7 +1171,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <i64 as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1181,7 +1182,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1190,7 +1191,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_i64(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1199,8 +1200,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1214,17 +1215,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_f64_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_f64::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_f64::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_f64::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <f64 as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <f64 as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1236,7 +1238,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <f64 as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1247,7 +1249,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1256,7 +1258,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_f64(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1265,8 +1267,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1280,17 +1282,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_type_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_type::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_type::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_type::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <MyType as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <MyType as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1302,7 +1305,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <MyType as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1313,7 +1316,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1322,7 +1325,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_type(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1331,8 +1334,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1346,17 +1349,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_enum_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_enum::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_enum::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_enum::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <MyEnum as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <MyEnum as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1368,7 +1372,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <MyEnum as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1379,7 +1383,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1388,7 +1392,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_enum(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1397,8 +1401,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1412,17 +1416,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_alias_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_alias::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_alias::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_alias::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <Uuid as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <Uuid as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1434,7 +1439,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <Uuid as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1445,7 +1450,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1454,7 +1459,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_alias(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1463,8 +1468,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1478,17 +1483,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_string_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_string::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_string::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_string::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <String as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <String as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1500,7 +1506,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <String as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1511,7 +1517,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1520,7 +1526,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_string(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1529,8 +1535,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1544,17 +1550,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_bool_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_bool::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_bool::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_bool::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <bool as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <bool as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1566,7 +1573,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <bool as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1577,7 +1584,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1586,7 +1593,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_bool(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1595,8 +1602,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1610,18 +1617,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_datetime_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_datetime::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_datetime::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_datetime::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
             <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(v)
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1633,7 +1640,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1644,7 +1651,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1653,7 +1660,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_datetime(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1662,8 +1669,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1677,18 +1684,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_list_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_list::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_list::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_list::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
             <Vec<String> as serde::Deserialize>::deserialize(v)
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1700,7 +1707,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <Vec<String> as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1711,7 +1718,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1720,7 +1727,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_list(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1729,8 +1736,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1744,18 +1751,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_map_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_map::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_map::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_map::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
             <std::collections::HashMap<String, String> as serde::Deserialize>::deserialize(v)
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1767,7 +1774,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <std::collections::HashMap<String, String> as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1778,7 +1785,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1787,7 +1794,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_map(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1796,8 +1803,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1811,11 +1818,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_i64_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_i64::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_i64::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_i64::Input {
           value: <i64 as serde::Deserialize>::deserialize(
@@ -1823,13 +1830,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <i64 as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <i64 as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1841,7 +1849,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <i64 as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1852,7 +1860,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1861,7 +1869,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_i64(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1870,8 +1878,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1885,11 +1893,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_f64_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_f64::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_f64::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_f64::Input {
           value: <f64 as serde::Deserialize>::deserialize(
@@ -1897,13 +1905,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <f64 as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <f64 as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1915,7 +1924,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <f64 as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -1926,7 +1935,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -1935,7 +1944,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_f64(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -1944,8 +1953,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -1959,11 +1968,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_type_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_type::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_type::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_type::Input {
           value: <MyType as serde::Deserialize>::deserialize(
@@ -1971,13 +1980,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <MyType as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <MyType as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -1989,7 +1999,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <MyType as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2000,7 +2010,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2009,7 +2019,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_type(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2018,8 +2028,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2033,11 +2043,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_enum_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_enum::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_enum::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_enum::Input {
           value: <MyEnum as serde::Deserialize>::deserialize(
@@ -2045,13 +2055,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <MyEnum as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <MyEnum as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -2063,7 +2074,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <MyEnum as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2074,7 +2085,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2083,7 +2094,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_enum(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2092,8 +2103,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2107,11 +2118,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_alias_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_alias::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_alias::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_alias::Input {
           value: <Uuid as serde::Deserialize>::deserialize(
@@ -2119,13 +2130,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <Uuid as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <Uuid as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -2137,7 +2149,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <Uuid as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2148,7 +2160,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2157,7 +2169,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_alias(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2166,8 +2178,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2181,31 +2193,30 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_string_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des =
-        move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_string::Input, Error> {
-          let mut map = deserialize_generic(&payload.data)?;
-          let input = my_streamer_service::request_channel_args_string::Input {
-            value: <String as serde::Deserialize>::deserialize(
-              map
-                .remove("value")
-                .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
-            )
-            .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
-            r#in: real_in_rx,
-          };
-
-          if let Some(v) = map.remove("in") {
-            let _ = in_inner_tx.send_result(
-              <String as serde::Deserialize>::deserialize(v)
-                .map_err(|e| PayloadError::application_error(e.to_string())),
-            );
-          }
-          Ok(input)
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_string::Input, Error> {
+        let mut map = deserialize_generic(&payload.data)?;
+        let input = my_streamer_service::request_channel_args_string::Input {
+          value: <String as serde::Deserialize>::deserialize(
+            map
+              .remove("value")
+              .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
+          )
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
+          r#in: real_in_rx,
         };
+
+        if let Some(v) = map.remove("in") {
+          let _ = in_inner_tx.send_result(
+            <String as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
+          );
+        }
+        Ok(input)
+      };
       let input_map = if let Ok(Some(Ok(first))) = input.recv().await {
         spawn(async move {
           while let Ok(Some(Ok(payload))) = input.recv().await {
@@ -2213,7 +2224,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <String as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2224,7 +2235,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2233,7 +2244,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_string(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2242,8 +2253,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2257,11 +2268,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_bool_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_bool::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_bool::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_bool::Input {
           value: <bool as serde::Deserialize>::deserialize(
@@ -2269,13 +2280,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <bool as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <bool as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -2287,7 +2299,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <bool as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2298,7 +2310,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2307,7 +2319,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_bool(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2316,8 +2328,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2331,31 +2343,30 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_datetime_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des =
-        move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_datetime::Input, Error> {
-          let mut map = deserialize_generic(&payload.data)?;
-          let input = my_streamer_service::request_channel_args_datetime::Input {
-            value: <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(
-              map
-                .remove("value")
-                .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
-            )
-            .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
-            r#in: real_in_rx,
-          };
-
-          if let Some(v) = map.remove("in") {
-            let _ = in_inner_tx.send_result(
-              <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(v)
-                .map_err(|e| PayloadError::application_error(e.to_string())),
-            );
-          }
-          Ok(input)
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_datetime::Input, Error> {
+        let mut map = deserialize_generic(&payload.data)?;
+        let input = my_streamer_service::request_channel_args_datetime::Input {
+          value: <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(
+            map
+              .remove("value")
+              .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
+          )
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
+          r#in: real_in_rx,
         };
+
+        if let Some(v) = map.remove("in") {
+          let _ = in_inner_tx.send_result(
+            <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
+          );
+        }
+        Ok(input)
+      };
       let input_map = if let Ok(Some(Ok(first))) = input.recv().await {
         spawn(async move {
           while let Ok(Some(Ok(payload))) = input.recv().await {
@@ -2363,7 +2374,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <wasmrs_guest::Timestamp as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2374,7 +2385,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2383,7 +2394,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_datetime(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2392,8 +2403,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2407,11 +2418,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_list_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_list::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_list::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_list::Input {
           value: <Vec<String> as serde::Deserialize>::deserialize(
@@ -2419,14 +2430,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
             <Vec<String> as serde::Deserialize>::deserialize(v)
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -2438,7 +2449,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <Vec<String> as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2449,7 +2460,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2458,7 +2469,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_list(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2467,8 +2478,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2482,11 +2493,11 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_args_map_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_args_map::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_args_map::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_args_map::Input {
           value: <std::collections::HashMap<String, String> as serde::Deserialize>::deserialize(
@@ -2494,14 +2505,14 @@ impl MyStreamerComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           r#in: real_in_rx,
         };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
             <std::collections::HashMap<String, String> as serde::Deserialize>::deserialize(v)
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -2513,7 +2524,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <std::collections::HashMap<String, String> as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2524,7 +2535,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2533,7 +2544,7 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_args_map(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
@@ -2542,8 +2553,8 @@ impl MyStreamerComponent {
               Ok(output) => {
                 let _ = real_out_tx.send_result(
                   serialize(&output)
-                    .map(|b| Payload::new_data(None, Some(b.into())))
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map(|b| RawPayload::new_data(None, Some(b.into())))
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
               Err(e) => {
@@ -2557,17 +2568,18 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_void_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
-      let des = move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_void::Input, Error> {
+      let des = move |payload: Payload| -> Result<my_streamer_service::request_channel_void::Input, Error> {
         let mut map = deserialize_generic(&payload.data)?;
         let input = my_streamer_service::request_channel_void::Input { r#in: real_in_rx };
 
         if let Some(v) = map.remove("in") {
           let _ = in_inner_tx.send_result(
-            <i64 as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+            <i64 as serde::Deserialize>::deserialize(v)
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
         Ok(input)
@@ -2579,7 +2591,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <i64 as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2590,7 +2602,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2599,14 +2611,14 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_void(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
           let _ = real_out_tx.send_result(
             serialize(&result)
-              .map(|b| Payload::new_data(None, Some(b.into())))
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map(|b| RawPayload::new_data(None, Some(b.into())))
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
       }
@@ -2614,18 +2626,19 @@ impl MyStreamerComponent {
     Ok(real_out_rx)
   }
   fn request_channel_non_stream_output_wrapper(input: IncomingStream) -> Result<OutgoingStream, GenericError> {
-    let (real_out_tx, real_out_rx) = Flux::new_channels();
-    let (real_in_tx, real_in_rx) = Flux::new_channels();
+    let (real_out_tx, real_out_rx) = FluxChannel::new_parts();
+    let (real_in_tx, real_in_rx) = FluxChannel::new_parts();
     let in_inner_tx = real_in_tx.clone();
     spawn(async move {
       let des =
-        move |payload: ParsedPayload| -> Result<my_streamer_service::request_channel_non_stream_output::Input, Error> {
+        move |payload: Payload| -> Result<my_streamer_service::request_channel_non_stream_output::Input, Error> {
           let mut map = deserialize_generic(&payload.data)?;
           let input = my_streamer_service::request_channel_non_stream_output::Input { r#in: real_in_rx };
 
           if let Some(v) = map.remove("in") {
             let _ = in_inner_tx.send_result(
-              <i64 as serde::Deserialize>::deserialize(v).map_err(|e| PayloadError::application_error(e.to_string())),
+              <i64 as serde::Deserialize>::deserialize(v)
+                .map_err(|e| PayloadError::application_error(e.to_string(), None)),
             );
           }
           Ok(input)
@@ -2637,7 +2650,7 @@ impl MyStreamerComponent {
               if let Some(a) = payload.remove("in") {
                 let _ = real_in_tx.send_result(
                   <i64 as serde::Deserialize>::deserialize(a)
-                    .map_err(|e| PayloadError::application_error(e.to_string())),
+                    .map_err(|e| PayloadError::application_error(e.to_string(), None)),
                 );
               }
             } else {
@@ -2648,7 +2661,7 @@ impl MyStreamerComponent {
         match des(first) {
           Ok(o) => o,
           Err(e) => {
-            let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+            let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
             return;
           }
         }
@@ -2657,14 +2670,14 @@ impl MyStreamerComponent {
       };
       match MyStreamerComponent::request_channel_non_stream_output(input_map).await {
         Err(e) => {
-          let _ = real_out_tx.error(PayloadError::application_error(e.to_string()));
+          let _ = real_out_tx.error(PayloadError::application_error(e.to_string(), None));
           return;
         }
         Ok(mut result) => {
           let _ = real_out_tx.send_result(
             serialize(&result)
-              .map(|b| Payload::new_data(None, Some(b.into())))
-              .map_err(|e| PayloadError::application_error(e.to_string())),
+              .map(|b| RawPayload::new_data(None, Some(b.into())))
+              .map_err(|e| PayloadError::application_error(e.to_string(), None)),
           );
         }
       }
@@ -3704,7 +3717,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_i64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_I64_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3725,7 +3738,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_f64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_F64_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3746,7 +3759,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_type::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_TYPE_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3767,7 +3780,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_enum::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ENUM_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3788,7 +3801,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_uuid::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_UUID_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3809,7 +3822,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_alias::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ALIAS_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3830,7 +3843,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_string::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_STRING_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3851,7 +3864,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_bool::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_BOOL_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3872,7 +3885,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_datetime::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_DATETIME_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_datetime::Output>(&payload.data.unwrap())?))?
@@ -3893,7 +3906,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_list::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_LIST_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3914,7 +3927,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_map::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_MAP_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default()
       .request_stream(payload)
@@ -3935,7 +3948,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_i64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_I64_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_i64::Output>(&payload.data.unwrap())?))?
@@ -3958,7 +3971,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_f64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_F64_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_f64::Output>(&payload.data.unwrap())?))?
@@ -3981,7 +3994,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_type::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_TYPE_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_type::Output>(&payload.data.unwrap())?))?
@@ -4004,7 +4017,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_enum::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_ENUM_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_enum::Output>(&payload.data.unwrap())?))?
@@ -4027,7 +4040,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_uuid::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_UUID_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_uuid::Output>(&payload.data.unwrap())?))?
@@ -4050,7 +4063,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_alias::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_ALIAS_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| {
@@ -4077,7 +4090,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_string::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_STRING_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| {
@@ -4104,7 +4117,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_bool::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_BOOL_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_bool::Output>(&payload.data.unwrap())?))?
@@ -4127,7 +4140,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_datetime::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_DATETIME_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| {
@@ -4154,7 +4167,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_list::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_LIST_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_list::Output>(&payload.data.unwrap())?))?
@@ -4177,7 +4190,7 @@ pub mod my_provider {
   ) -> impl Stream<Item = Result<request_stream_args_map::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_STREAM_ARGS_MAP_INDEX_BYTES.as_slice();
     let payload = wasmrs_guest::serialize(&input)
-      .map(|bytes| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
+      .map(|bytes| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()))
       .unwrap();
     Host::default().request_stream(payload).map(|result| {
       result.map(|payload| Ok(deserialize::<request_stream_args_map::Output>(&payload.data.unwrap())?))?
@@ -4199,7 +4212,7 @@ pub mod my_provider {
     mut input: request_channel_i64::Input,
   ) -> impl Stream<Item = Result<request_channel_i64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_I64_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4220,19 +4233,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_i64::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4253,7 +4266,7 @@ pub mod my_provider {
     mut input: request_channel_f64::Input,
   ) -> impl Stream<Item = Result<request_channel_f64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_F64_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4274,19 +4287,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_f64::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4307,7 +4320,7 @@ pub mod my_provider {
     mut input: request_channel_type::Input,
   ) -> impl Stream<Item = Result<request_channel_type::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_TYPE_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4328,19 +4341,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_type::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4361,7 +4374,7 @@ pub mod my_provider {
     mut input: request_channel_enum::Input,
   ) -> impl Stream<Item = Result<request_channel_enum::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ENUM_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4382,19 +4395,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_enum::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4415,7 +4428,7 @@ pub mod my_provider {
     mut input: request_channel_alias::Input,
   ) -> impl Stream<Item = Result<request_channel_alias::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ALIAS_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4436,19 +4449,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_alias::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4469,7 +4482,7 @@ pub mod my_provider {
     mut input: request_channel_string::Input,
   ) -> impl Stream<Item = Result<request_channel_string::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_STRING_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4490,19 +4503,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_string::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4523,7 +4536,7 @@ pub mod my_provider {
     mut input: request_channel_bool::Input,
   ) -> impl Stream<Item = Result<request_channel_bool::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_BOOL_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4544,19 +4557,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_bool::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4577,7 +4590,7 @@ pub mod my_provider {
     mut input: request_channel_datetime::Input,
   ) -> impl Stream<Item = Result<request_channel_datetime::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_DATETIME_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4598,18 +4611,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| Ok(deserialize::<request_channel_datetime::Output>(&payload.data.unwrap())?))?
     })
   }
@@ -4631,7 +4644,7 @@ pub mod my_provider {
     mut input: request_channel_list::Input,
   ) -> impl Stream<Item = Result<request_channel_list::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_LIST_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4652,19 +4665,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_list::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4685,7 +4698,7 @@ pub mod my_provider {
     mut input: request_channel_map::Input,
   ) -> impl Stream<Item = Result<request_channel_map::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_MAP_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4706,19 +4719,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_map::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -4739,7 +4752,7 @@ pub mod my_provider {
     mut input: request_channel_args_i64::Input,
   ) -> impl Stream<Item = Result<request_channel_args_i64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_I64_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4760,18 +4773,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| Ok(deserialize::<request_channel_args_i64::Output>(&payload.data.unwrap())?))?
     })
   }
@@ -4796,7 +4809,7 @@ pub mod my_provider {
     mut input: request_channel_args_f64::Input,
   ) -> impl Stream<Item = Result<request_channel_args_f64::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_F64_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4817,18 +4830,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| Ok(deserialize::<request_channel_args_f64::Output>(&payload.data.unwrap())?))?
     })
   }
@@ -4853,7 +4866,7 @@ pub mod my_provider {
     mut input: request_channel_args_type::Input,
   ) -> impl Stream<Item = Result<request_channel_args_type::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_TYPE_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4874,18 +4887,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_type::Output>(
           &payload.data.unwrap(),
@@ -4914,7 +4927,7 @@ pub mod my_provider {
     mut input: request_channel_args_enum::Input,
   ) -> impl Stream<Item = Result<request_channel_args_enum::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_ENUM_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4935,18 +4948,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_enum::Output>(
           &payload.data.unwrap(),
@@ -4975,7 +4988,7 @@ pub mod my_provider {
     mut input: request_channel_args_alias::Input,
   ) -> impl Stream<Item = Result<request_channel_args_alias::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_ALIAS_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -4996,18 +5009,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_alias::Output>(
           &payload.data.unwrap(),
@@ -5036,7 +5049,7 @@ pub mod my_provider {
     mut input: request_channel_args_string::Input,
   ) -> impl Stream<Item = Result<request_channel_args_string::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_STRING_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5057,18 +5070,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_string::Output>(
           &payload.data.unwrap(),
@@ -5097,7 +5110,7 @@ pub mod my_provider {
     mut input: request_channel_args_bool::Input,
   ) -> impl Stream<Item = Result<request_channel_args_bool::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_BOOL_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5118,18 +5131,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_bool::Output>(
           &payload.data.unwrap(),
@@ -5158,7 +5171,7 @@ pub mod my_provider {
     mut input: request_channel_args_datetime::Input,
   ) -> impl Stream<Item = Result<request_channel_args_datetime::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_DATETIME_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5179,18 +5192,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_datetime::Output>(
           &payload.data.unwrap(),
@@ -5219,7 +5232,7 @@ pub mod my_provider {
     mut input: request_channel_args_list::Input,
   ) -> impl Stream<Item = Result<request_channel_args_list::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_LIST_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5240,18 +5253,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_args_list::Output>(
           &payload.data.unwrap(),
@@ -5280,7 +5293,7 @@ pub mod my_provider {
     mut input: request_channel_args_map::Input,
   ) -> impl Stream<Item = Result<request_channel_args_map::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_ARGS_MAP_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5301,18 +5314,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| Ok(deserialize::<request_channel_args_map::Output>(&payload.data.unwrap())?))?
     })
   }
@@ -5337,7 +5350,7 @@ pub mod my_provider {
     mut input: request_channel_void::Input,
   ) -> impl Stream<Item = Result<request_channel_void::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_VOID_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5358,19 +5371,19 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
     Host::default()
-      .request_channel(rx)
+      .request_channel(Box::new(rx))
       .map(|result| result.map(|payload| Ok(deserialize::<request_channel_void::Output>(&payload.data.unwrap())?))?)
   }
 
@@ -5391,7 +5404,7 @@ pub mod my_provider {
     mut input: request_channel_non_stream_output::Input,
   ) -> impl Stream<Item = Result<request_channel_non_stream_output::Output, PayloadError>> {
     let op_id_bytes = MY_PROVIDER_REQUEST_CHANNEL_NON_STREAM_OUTPUT_INDEX_BYTES.as_slice();
-    let (tx, rx) = Flux::new_channels();
+    let (tx, rx) = FluxChannel::new_parts();
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     enum OpInputs {
@@ -5412,18 +5425,18 @@ pub mod my_provider {
         };
         let message = OpInputs::In(payload);
         let payload = wasmrs_guest::serialize(&message)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()));
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None));
         let _ = tx_inner.send_result(payload);
       }
     });
 
     let payload = wasmrs_guest::serialize(&first)
-      .map(|b| Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
-      .map_err(|e| PayloadError::application_error(e.to_string()));
+      .map(|b| RawPayload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), b.into()))
+      .map_err(|e| PayloadError::application_error(e.to_string(), None));
     let _ = tx.send_result(payload);
 
-    Host::default().request_channel(rx).map(|result| {
+    Host::default().request_channel(Box::new(rx)).map(|result| {
       result.map(|payload| {
         Ok(deserialize::<request_channel_non_stream_output::Output>(
           &payload.data.unwrap(),
@@ -5463,22 +5476,16 @@ impl MyServiceComponent {
       fn des(_map: std::collections::BTreeMap<String, Value>) -> Result<my_service_service::empty_void::Input, Error> {
         unreachable!()
       }
-      let _ = MyServiceComponent::empty_void(match des(input_payload) {
-        Ok(o) => o,
-        Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
-          return;
-        }
-      })
-      .await
-      .map(|result| {
-        serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
-      })
-      .map(|output| {
-        let _ = tx.send(output);
-      });
+      let _ = MyServiceComponent::empty_void(my_service_service::empty_void::Input {})
+        .await
+        .map(|result| {
+          serialize(&result)
+            .map(|b| RawPayload::new_data(None, Some(b.into())))
+            .map_err(|e| PayloadError::application_error(e.to_string(), None))
+        })
+        .map(|output| {
+          let _ = tx.send(output);
+        });
     });
     Ok(Mono::from_future(async move { rx.await? }))
   }
@@ -5500,21 +5507,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_type(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5540,21 +5547,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_enum(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5580,21 +5587,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_uuid(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5620,21 +5627,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_alias(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5660,21 +5667,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_string(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5700,21 +5707,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_i64(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5740,21 +5747,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_i32(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5780,21 +5787,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_i16(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5820,21 +5827,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_i8(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5860,21 +5867,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_u64(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5900,21 +5907,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_u32(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5940,21 +5947,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_u16(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -5980,21 +5987,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_u8(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6020,21 +6027,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_f64(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6060,21 +6067,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_f32(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6100,21 +6107,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_bytes(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6140,21 +6147,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_datetime(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6180,21 +6187,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_list(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6222,21 +6229,21 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         )
       }
       let _ = MyServiceComponent::unary_map(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6264,27 +6271,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<MyType> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_type(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6312,27 +6319,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<MyEnum> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_enum(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6360,27 +6367,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<Uuid> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_uuid(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6408,27 +6415,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<MyAlias> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_alias(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6456,27 +6463,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<String> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_string(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6502,27 +6509,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<i64> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_i64(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6548,27 +6555,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<i32> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_i32(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6594,27 +6601,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<i16> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_i16(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6640,27 +6647,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<i8> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_i8(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6686,27 +6693,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<u64> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_u64(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6732,27 +6739,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<u32> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_u32(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6778,27 +6785,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<u16> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_u16(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6824,27 +6831,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<u8> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_u8(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6870,27 +6877,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<f64> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_f64(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6916,27 +6923,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<f32> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_f32(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -6964,27 +6971,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<wasmrs_guest::Bytes> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_bytes(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -7012,27 +7019,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<wasmrs_guest::Timestamp> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_datetime(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -7060,27 +7067,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<Vec<String>> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_list(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);
@@ -7106,27 +7113,27 @@ impl MyServiceComponent {
               .remove("value")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("value".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
           optional: <Option<std::collections::HashMap<String, String>> as serde::Deserialize>::deserialize(
             map
               .remove("optional")
               .ok_or_else(|| wasmrs_guest::Error::MissingInput("optional".to_owned()))?,
           )
-          .map_err(|e| wasmrs_guest::Error::Decode(e.to_string()))?,
+          .map_err(|e| wasmrs_guest::Error::Codec(e.to_string()))?,
         })
       }
       let _ = MyServiceComponent::func_map(match des(input_payload) {
         Ok(o) => o,
         Err(e) => {
-          let _ = tx.send(Err(PayloadError::application_error(e.to_string())));
+          let _ = tx.send(Err(PayloadError::application_error(e.to_string(), None)));
           return;
         }
       })
       .await
       .map(|result| {
         serialize(&result)
-          .map(|b| Payload::new_data(None, Some(b.into())))
-          .map_err(|e| PayloadError::application_error(e.to_string()))
+          .map(|b| RawPayload::new_data(None, Some(b.into())))
+          .map_err(|e| PayloadError::application_error(e.to_string(), None))
       })
       .map(|output| {
         let _ = tx.send(output);

--- a/wasm/grabbag/src/actions/mod.rs
+++ b/wasm/grabbag/src/actions/mod.rs
@@ -5487,7 +5487,10 @@ impl MyServiceComponent {
           let _ = tx.send(output);
         });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_type_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5527,7 +5530,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_enum_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5567,7 +5573,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_uuid_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5607,7 +5616,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_alias_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5647,7 +5659,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_string_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5687,7 +5702,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_i64_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5727,7 +5745,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_i32_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5767,7 +5788,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_i16_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5807,7 +5831,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_i8_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5847,7 +5874,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_u64_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5887,7 +5917,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_u32_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5927,7 +5960,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_u16_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -5967,7 +6003,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_u8_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6007,7 +6046,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_f64_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6047,7 +6089,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_f32_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6087,7 +6132,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_bytes_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6127,7 +6175,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_datetime_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6167,7 +6218,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_list_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6207,7 +6261,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn unary_map_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6249,7 +6306,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_type_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6297,7 +6357,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_enum_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6345,7 +6408,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_uuid_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6393,7 +6459,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_alias_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6441,7 +6510,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_string_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6489,7 +6561,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_i64_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6535,7 +6610,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_i32_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6581,7 +6659,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_i16_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6627,7 +6708,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_i8_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6673,7 +6757,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_u64_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6719,7 +6806,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_u32_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6765,7 +6855,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_u16_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6811,7 +6904,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_u8_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6857,7 +6953,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_f64_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6903,7 +7002,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_f32_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6949,7 +7051,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_bytes_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -6997,7 +7102,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_datetime_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -7045,7 +7153,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_list_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -7093,7 +7204,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn func_map_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -7139,7 +7253,10 @@ impl MyServiceComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
 }
 

--- a/wasm/grabbag/src/actions/test/chars.rs
+++ b/wasm/grabbag/src/actions/test/chars.rs
@@ -1,7 +1,7 @@
 use crate::actions::test_service::chars::*;
 
 pub(crate) async fn task(input: Inputs) -> Result<Outputs, crate::Error> {
-  let stream = Flux::new();
+  let stream = FluxChannel::new();
   for c in input.input.chars() {
     stream.send(c.to_string()).unwrap();
   }

--- a/wasm/grabbag/src/actions/test/reverse.rs
+++ b/wasm/grabbag/src/actions/test/reverse.rs
@@ -2,7 +2,7 @@ use crate::actions::test_service::reverse::*;
 
 pub(crate) async fn task(mut input: Inputs) -> Result<Outputs, crate::Error> {
   println!("starting task");
-  let (tx, rx) = Flux::new_channels();
+  let (tx, rx) = FluxChannel::new_parts();
   spawn(async move {
     while let Some(c) = input.input.next().await {
       println!("got input {:?}", c);

--- a/wasm/grabbag/src/actions/test/wrap.rs
+++ b/wasm/grabbag/src/actions/test/wrap.rs
@@ -1,7 +1,7 @@
 use crate::actions::test_service::wrap::*;
 
 pub(crate) async fn task(mut input: Inputs) -> Result<Outputs, crate::Error> {
-  let output = Flux::new();
+  let output = FluxChannel::new();
   while let Some(msg) = input.input.next().await {
     let msg = msg?;
     let wrapped = format!("{}{}{}", input.left, msg, input.right);

--- a/wasm/reqres-component/Cargo.lock
+++ b/wasm/reqres-component/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bytes",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-codec"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "heapless",
  "serde",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-frames"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "serde",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-guest"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-rx"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/wasm/reqres-component/apex.yaml
+++ b/wasm/reqres-component/apex.yaml
@@ -2,4 +2,4 @@ spec: ./apex.axdl
 config:
   name: 'reqres-component'
 plugins:
-  - '../../../wasmrs-codegen/src/rust/plugin.ts'
+  - 'https://raw.githubusercontent.com/WasmRS/codegen/main/src/rust/plugin.ts'

--- a/wasm/reqres-component/apex.yaml
+++ b/wasm/reqres-component/apex.yaml
@@ -2,4 +2,4 @@ spec: ./apex.axdl
 config:
   name: 'reqres-component'
 plugins:
-  - '../../../codegen/src/rust/plugin.ts'
+  - '../../../wasmrs-codegen/src/rust/plugin.ts'

--- a/wasm/reqres-component/src/actions/mod.rs
+++ b/wasm/reqres-component/src/actions/mod.rs
@@ -64,7 +64,10 @@ impl TestComponent {
           let _ = tx.send(output);
         });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn echo_wrapper(input: IncomingMono) -> Result<OutgoingMono, GenericError> {
     let (tx, rx) = runtime::oneshot();
@@ -104,7 +107,10 @@ impl TestComponent {
         let _ = tx.send(output);
       });
     });
-    Ok(Mono::from_future(async move { rx.await? }))
+    Ok(Mono::from_future(async move {
+      rx.await
+        .map_err(|e| PayloadError::application_error(e.to_string(), None))?
+    }))
   }
   fn chars_wrapper(input: IncomingMono) -> Result<OutgoingStream, GenericError> {
     let (out_tx, out_rx) = FluxChannel::new_parts();

--- a/wasm/reqres-component/src/actions/test/chars.rs
+++ b/wasm/reqres-component/src/actions/test/chars.rs
@@ -1,10 +1,10 @@
 use crate::actions::test_service::chars::*;
 
 pub(crate) async fn task(input: Input) -> Result<Output, crate::Error> {
-  let stream = Flux::new();
+  let (tx, output) = FluxChannel::new_parts();
   for c in input.input.chars() {
-    stream.send(c.to_string()).unwrap();
+    tx.send(c.to_string()).unwrap();
   }
-  stream.complete();
-  Ok(stream.take_rx()?)
+  tx.complete();
+  Ok(output)
 }

--- a/wasm/reqres-component/src/actions/test/reverse.rs
+++ b/wasm/reqres-component/src/actions/test/reverse.rs
@@ -2,7 +2,7 @@ use crate::actions::test_service::reverse::*;
 
 pub(crate) async fn task(mut input: Input) -> Result<Output, crate::Error> {
   println!("starting task");
-  let (tx, rx) = Flux::new_channels();
+  let (tx, rx) = FluxChannel::new_parts();
   spawn(async move {
     while let Some(c) = input.input.next().await {
       println!("got input {:?}", c);
@@ -12,7 +12,7 @@ pub(crate) async fn task(mut input: Input) -> Result<Output, crate::Error> {
           println!("sending output {:?}", reversed);
           tx.send(reversed).unwrap();
         }
-        Err(e) => tx.error(PayloadError::application_error(e.to_string())).unwrap(),
+        Err(e) => tx.error(PayloadError::application_error(e.to_string(), None)).unwrap(),
       }
     }
     tx.complete();

--- a/wasm/reqres-component/src/actions/test/wrap.rs
+++ b/wasm/reqres-component/src/actions/test/wrap.rs
@@ -1,12 +1,12 @@
 use crate::actions::test_service::wrap::*;
 
 pub(crate) async fn task(mut input: Input) -> Result<Output, crate::Error> {
-  let output = Flux::new();
+  let (tx, output) = FluxChannel::new_parts();
   while let Some(msg) = input.input.next().await {
     let msg = msg?;
     let wrapped = format!("{}{}{}", input.left, msg, input.right);
     println!("sending output {:?}", wrapped);
-    output.send(wrapped).unwrap();
+    tx.send(wrapped).unwrap();
   }
-  Ok(output.take_rx()?)
+  Ok(output)
 }

--- a/wasm/reqres-component/src/error.rs
+++ b/wasm/reqres-component/src/error.rs
@@ -2,6 +2,7 @@
 pub enum Error {
   #[error(transparent)]
   PayloadError(#[from] wasmrs_guest::PayloadError),
+
   #[error(transparent)]
   Protocol(#[from] wasmrs_guest::Error),
 


### PR DESCRIPTION
This PR:
- Renames Flux to FluxChannel, FluxLike to Flux, Payload to RawPayload, and ParsedPayload to Payload.
- Adds the concept of metadata to Error Frames to catch cases where errors are related to payload metadata. Error frames without metadata operate as normal.
- Adds license & contributing files to the repo
- Cleans up links and terminology.
- Adds tests for rust host callbacks.