### PR TITLE
Removed compile-time feature that breaks logging in consumers

### DIFF
--- a/crates/wasmrs-guest/Cargo.toml
+++ b/crates/wasmrs-guest/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true, features = [
   "derive",
   "alloc",
 ], default-features = false }
-tracing = { workspace = true, features = ["log", "release_max_level_off"] }
+tracing = { workspace = true, features = ["log"] }
 serde_json = "1.0"
 env_logger = { workspace = true, optional = true }
 log = { version = "0.4", optional = true }

--- a/crates/wasmrs-rx/Cargo.toml
+++ b/crates/wasmrs-rx/Cargo.toml
@@ -12,7 +12,7 @@ wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.5.0" }
 futures = { workspace = true, default-features = false }
 bytes = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = false }
-tracing = { workspace = true, features = ["release_max_level_off"] }
+tracing = { workspace = true }
 pin-project-lite = "0.2"
 async-trait = { workspace = true }
 

--- a/crates/wasmrs/Cargo.toml
+++ b/crates/wasmrs/Cargo.toml
@@ -27,7 +27,7 @@ wasmrs-rx = { path = "../wasmrs-rx", version = "0.5.0" }
 futures = { workspace = true, default-features = false }
 bytes = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = false }
-tracing = { workspace = true, features = ["release_max_level_off"] }
+tracing = { workspace = true }
 pin-project-lite = "0.2"
 # For recording frames
 once_cell = { version = "1.8", optional = true }


### PR DESCRIPTION
This PR removes some of the compile-time features for the `tracing` crate that disables tracing in any dependent.