### PR TITLE
chore: bumped wasm-msgpack

### DIFF
--- a/crates/wasmrs-codec/Cargo.toml
+++ b/crates/wasmrs-codec/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 [dependencies]
 wasmrs-frames = { path = "../wasmrs-frames", version = "0.9.0" }
-wasm-msgpack = { version = "0.5" }
+wasm-msgpack = { version = "0.6" }
 serde = { version = "1", features = [], default-features = false }
 heapless = "0.7"
 


### PR DESCRIPTION
This PR bumps `wasm-msgpack` to fix nil/unit encoding.