### PR TITLE
Migrated to rmp-serde, fixed issue with buffer sizes not updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /Cargo.lock
 /**/target
 */frames/*.frame
+
+.DS_store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ members = [
 exclude = ["wasm/reqres-component", "wasm/baseline", "wasm/grabbag"]
 
 [workspace.dependencies]
-env_logger = "0.10.0"
-futures = "0.3"
-futures-core = "0.3"
-futures-executor = "0.3"
-futures-util = "0.3"
-serde = "1"
-bytes = "1.2"
-tokio = "1"
-async-trait = "0.1"
-parking_lot = "0.12"
-tracing = "0.1"
-thiserror = "1.0"
-anyhow = "1.0"
+env_logger = { version = "0.10.0", default-features = false }
+futures = { version = "0.3", default-features = false }
+futures-core = { version = "0.3", default-features = false }
+futures-executor = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
+serde = { version = "1", default-features = false }
+bytes = { version = "1.2", default-features = false }
+tokio = { version = "1", default-features = false }
+async-trait = { version = "0.1", default-features = false }
+parking_lot = { version = "0.12", default-features = false }
+tracing = { version = "0.1", default-features = false }
+thiserror = { version = "1.0", default-features = false }
+anyhow = { version = "1.0", default-features = false }

--- a/crates/wasmrs-codec/Cargo.toml
+++ b/crates/wasmrs-codec/Cargo.toml
@@ -8,10 +8,12 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
+default = []
+std = ["serde/std"]
 
 [dependencies]
 wasmrs-frames = { path = "../wasmrs-frames", version = "0.12.0" }
-wasm-msgpack = { version = "0.6" }
+rmp-serde = "1.1"
 serde = { version = "1", features = [], default-features = false }
 heapless = "0.7"
 

--- a/crates/wasmrs-codec/src/error.rs
+++ b/crates/wasmrs-codec/src/error.rs
@@ -1,7 +1,7 @@
 #[derive(Debug)]
 pub enum Error {
-  MsgPackDecode(wasm_msgpack::decode::Error),
-  MsgPackEncode(wasm_msgpack::encode::Error),
+  MsgPackDecode(rmp_serde::decode::Error),
+  MsgPackEncode(rmp_serde::encode::Error),
 }
 
 #[cfg(feature = "std")]

--- a/crates/wasmrs-codec/src/lib.rs
+++ b/crates/wasmrs-codec/src/lib.rs
@@ -1,6 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod error;
 pub mod messagepack;
-
-pub use wasm_msgpack::timestamp::Timestamp;

--- a/crates/wasmrs-codec/src/messagepack.rs
+++ b/crates/wasmrs-codec/src/messagepack.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-pub use wasm_msgpack::timestamp::Timestamp;
 
 use crate::error::Error;
 use core::result::Result;
@@ -7,13 +6,16 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 #[doc(hidden)]
-pub fn mp_serialize<T>(item: &T) -> Result<Vec<u8>, wasm_msgpack::encode::Error>
+pub fn mp_serialize<T>(item: &T) -> Result<Vec<u8>, rmp_serde::encode::Error>
 where
   T: ?Sized + Serialize,
 {
-  let mut buf = [0; 1024 * 100];
-  let written = wasm_msgpack::encode::serde::to_array(item, &mut buf)?;
-  Ok(buf[0..written].to_vec())
+  let mut buf = Vec::new();
+  let mut serializer = rmp_serde::encode::Serializer::new(&mut buf)
+    .with_human_readable()
+    .with_struct_map();
+  item.serialize(&mut serializer)?;
+  Ok(buf)
 }
 
 /// The standard function for serializing codec structs into a format that can be.
@@ -27,8 +29,8 @@ where
 }
 
 #[doc(hidden)]
-pub fn mp_deserialize<'de, T: Deserialize<'de>>(buf: &'de [u8]) -> Result<T, wasm_msgpack::decode::Error> {
-  wasm_msgpack::decode::from_slice(buf)
+pub fn mp_deserialize<'de, T: Deserialize<'de>>(buf: &'de [u8]) -> Result<T, rmp_serde::decode::Error> {
+  rmp_serde::decode::from_slice(buf)
 }
 
 /// The standard function for de-serializing codec structs from a format suitable.

--- a/crates/wasmrs-guest/Cargo.toml
+++ b/crates/wasmrs-guest/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 default = []
 logging = ["env_logger", "log", "wasmrs-runtime/logging"]
 record-frames = ["wasmrs/record-frames"]
+std = ["wasmrs-codec/std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/crates/wasmrs-guest/src/lib.rs
+++ b/crates/wasmrs-guest/src/lib.rs
@@ -95,7 +95,6 @@ pub mod error;
 
 pub use serde_json::Value;
 pub use wasmrs::Payload;
-pub use wasmrs_codec::Timestamp;
 pub use wasmrs_rx::{BoxFlux, BoxMono};
 
 /// Deserialize a generic [Value] from CBOR bytes.

--- a/crates/wasmrs-rx/Cargo.toml
+++ b/crates/wasmrs-rx/Cargo.toml
@@ -9,7 +9,9 @@ repository = "https://github.com/wasmrs/wasmrs-rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 wasmrs-runtime = { path = "../wasmrs-runtime", version = "0.12.0" }
-futures = { workspace = true, default-features = false }
+futures = { workspace = true, default-features = false, features = [
+  "io-compat"
+] }
 bytes = { workspace = true, default-features = false }
 parking_lot = { workspace = true, default-features = false }
 tracing = { workspace = true }

--- a/crates/wasmrs-testhost/tests/replays.rs
+++ b/crates/wasmrs-testhost/tests/replays.rs
@@ -14,7 +14,7 @@ static REPLAYS: [&str; 2] = [
 ];
 
 #[test_log::test(tokio::test)]
-async fn test_iota_req_channel() -> anyhow::Result<()> {
+async fn test_req_channel() -> anyhow::Result<()> {
   let engine = WasmtimeBuilder::new(MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;

--- a/crates/wasmrs-wasmtime/Cargo.toml
+++ b/crates/wasmrs-wasmtime/Cargo.toml
@@ -29,7 +29,8 @@ anyhow = { version = "1.0" }
 [dev-dependencies]
 env_logger = { workspace = true }
 wasmrs-rx = { path = "../wasmrs-rx", version = "0.12.0" }
-wasmrs-codec = { path = "../wasmrs-codec", version = "0.12.0" }
+wasmrs-codec = { path = "../wasmrs-codec", version = "0.12.0", features = [
+] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 test-log = "0.2.10"
 serde = { workspace = true }

--- a/crates/wasmrs-wasmtime/src/engine_provider.rs
+++ b/crates/wasmrs-wasmtime/src/engine_provider.rs
@@ -176,6 +176,9 @@ impl ProviderCallContext for WasmtimeCallContext {
       .call(&mut self.store, (host_buffer_size, guest_buffer_size, 128))
       .map_err(|e| wasmrs_host::errors::Error::InitFailed(e.to_string()))?;
 
+    self.store.data().guest_buffer.update_size(guest_buffer_size);
+    self.store.data().host_buffer.update_size(host_buffer_size);
+
     if let Ok(oplist) = self
       .instance
       .get_typed_func::<(), ()>(&mut self.store, GuestExports::OpListRequest.as_ref())

--- a/crates/wasmrs-wasmtime/tests/request_channel.rs
+++ b/crates/wasmrs-wasmtime/tests/request_channel.rs
@@ -10,7 +10,7 @@ use wasmrs_wasmtime::WasmtimeBuilder;
 static MODULE_BYTES: &[u8] = include_bytes!("../../../build/reqres_component.wasm");
 
 #[test_log::test(tokio::test)]
-async fn test_iota_req_channel_single() -> anyhow::Result<()> {
+async fn test_req_channel_single() -> anyhow::Result<()> {
   let engine = WasmtimeBuilder::new(MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
@@ -58,7 +58,7 @@ async fn test_iota_req_channel_single() -> anyhow::Result<()> {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_iota_req_channel_multi() -> anyhow::Result<()> {
+async fn test_req_channel_multi() -> anyhow::Result<()> {
   let engine = WasmtimeBuilder::new(MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;

--- a/crates/wasmrs-wasmtime/tests/request_response.rs
+++ b/crates/wasmrs-wasmtime/tests/request_response.rs
@@ -6,7 +6,7 @@ use wasmrs_wasmtime::WasmtimeBuilder;
 static MODULE_BYTES: &[u8] = include_bytes!("../../../build/reqres_component.wasm");
 
 #[test_log::test(tokio::test)]
-async fn test_iota_req_response() -> anyhow::Result<()> {
+async fn test_req_response() -> anyhow::Result<()> {
   let engine = WasmtimeBuilder::new(MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;

--- a/crates/wasmrs-wasmtime/tests/request_stream.rs
+++ b/crates/wasmrs-wasmtime/tests/request_stream.rs
@@ -9,7 +9,7 @@ use wasmrs_wasmtime::WasmtimeBuilder;
 static MODULE_BYTES: &[u8] = include_bytes!("../../../build/reqres_component.wasm");
 
 #[test_log::test(tokio::test)]
-async fn test_iota_req_stream() -> anyhow::Result<()> {
+async fn test_req_stream() -> anyhow::Result<()> {
   let engine = WasmtimeBuilder::new(MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;

--- a/justfile
+++ b/justfile
@@ -1,13 +1,16 @@
+# Apex-oriented projects have gone stale but can still
+# be used as regression tests.
+
 wasm:
     mkdir -p build
-    just wasm/reqres-component/build
-    just wasm/grabbag/build
+    # just wasm/reqres-component/build
+    # just wasm/grabbag/build
     just wasm/baseline/build
 
 debug:
     mkdir -p build
-    just wasm/reqres-component/debug
-    just wasm/grabbag/debug
+    # just wasm/reqres-component/debug
+    # just wasm/grabbag/debug
     just wasm/baseline/debug
 
 test:
@@ -17,6 +20,6 @@ test:
 clean:
   cargo clean
   rm -rf build/*
-  just wasm/reqres-component/clean
-  just wasm/grabbag/clean
+  # just wasm/reqres-component/clean
+  # just wasm/grabbag/clean
   just wasm/baseline/clean

--- a/wasm/baseline/Cargo.lock
+++ b/wasm/baseline/Cargo.lock
@@ -50,6 +50,16 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
+
+[[package]]
+name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
@@ -103,13 +113,18 @@ dependencies = [
 
 [[package]]
 name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+
+[[package]]
+name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -150,17 +165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,16 +182,17 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+ "tokio-io",
 ]
 
 [[package]]
@@ -216,6 +221,15 @@ dependencies = [
  "rustc_version",
  "spin",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -339,6 +353,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,15 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -458,6 +485,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "log",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,28 +535,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
-name = "wasm-msgpack"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735069dc7fd3658648eba17e22cc4c1676b6a691bace11eef3cfaeea8da6256e"
-dependencies = [
- "byteorder",
- "heapless",
- "num-traits",
- "paste",
- "serde",
- "serde_bytes",
- "zerocopy",
-]
-
-[[package]]
 name = "wasmrs"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
- "bytes",
+ "bytes 1.3.0",
  "crossbeam-channel",
  "dashmap",
- "futures",
+ "futures 0.3.25",
  "futures-executor",
  "futures-util",
  "parking_lot",
@@ -533,26 +556,26 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-codec"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "heapless",
+ "rmp-serde",
  "serde",
- "wasm-msgpack",
  "wasmrs-frames",
 ]
 
 [[package]]
 name = "wasmrs-frames"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
- "bytes",
+ "bytes 1.3.0",
 ]
 
 [[package]]
 name = "wasmrs-guest"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
- "bytes",
+ "bytes 1.3.0",
  "cfg-if",
  "futures-executor",
  "futures-util",
@@ -568,29 +591,30 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-runtime"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
- "bytes",
+ "bytes 1.3.0",
  "crossbeam-channel",
  "dashmap",
- "futures",
+ "futures 0.3.25",
  "futures-executor",
  "futures-util",
  "parking_lot",
  "pin-project-lite",
  "tokio",
+ "tracing",
  "wasmrs-frames",
 ]
 
 [[package]]
 name = "wasmrs-rx"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.3.0",
  "crossbeam-channel",
  "dashmap",
- "futures",
+ "futures 0.3.25",
  "futures-executor",
  "futures-util",
  "parking_lot",
@@ -655,24 +679,3 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/wasm/reqres-component/Cargo.lock
+++ b/wasm/reqres-component/Cargo.lock
@@ -656,9 +656,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "wasm-msgpack"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b26eaeb28a70b042ee943c8d360e47d703f45931906e373d948d443733db9c5"
+checksum = "c566f7770882bb305d56f393e411f4a15b3b3e8404be914d183cc3cd35c3f733"
 dependencies = [
  "byteorder",
  "heapless",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "bytes",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-codec"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "heapless",
  "serde",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-frames"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "serde",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-guest"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "wasmrs-runtime"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -744,12 +744,13 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "tokio",
+ "tracing",
  "wasmrs-frames",
 ]
 
 [[package]]
 name = "wasmrs-rx"
-version = "0.8.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",


### PR DESCRIPTION
This PR:
- moves from wasm-msgpack to rmp-serde for compatibility
- fixes an issue with the internal assumption of buffer sizes not updating in sync with the `init` call.