### PR TITLE
Gave more control over reuse to dependent, bumped wasmtime

### DIFF
--- a/bins/ops/src/main.rs
+++ b/bins/ops/src/main.rs
@@ -15,8 +15,9 @@ async fn main() -> anyhow::Result<()> {
   env_logger::init();
   let args = Args::parse();
 
-  let module_bytes = std::fs::read(args.module)?;
-  let engine = WasmtimeBuilder::new(&module_bytes)
+  let module_bytes = std::fs::read(&args.module)?;
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes(&args.module, &module_bytes)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;

--- a/bins/request/src/main.rs
+++ b/bins/request/src/main.rs
@@ -45,8 +45,9 @@ async fn main() -> anyhow::Result<()> {
   env_logger::init();
   let args = Args::parse();
 
-  let module_bytes = std::fs::read(args.module)?;
-  let engine = WasmtimeBuilder::new(&module_bytes)
+  let module_bytes = std::fs::read(&args.module)?;
+  let engine = WasmtimeBuilder::new()
+  .with_module_bytes(&args.module, &module_bytes)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;

--- a/crates/wasmrs-testhost/Cargo.toml
+++ b/crates/wasmrs-testhost/Cargo.toml
@@ -20,9 +20,9 @@ parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }
 bytes = { workspace = true }
 futures = { workspace = true }
-wasmtime = "7.0.0"
-wasmtime-wasi = { version = "7.0.0", features = ["sync"] }
-wasi-common = { version = "7.0.0" }
+wasmtime = "10.0.1"
+wasmtime-wasi = { version = "10.0.1", features = ["sync"] }
+wasi-common = { version = "10.0.1" }
 cfg-if = "1.0.0"
 anyhow = { version = "1.0" }
 base64 = "0.21"

--- a/crates/wasmrs-wasmtime/Cargo.toml
+++ b/crates/wasmrs-wasmtime/Cargo.toml
@@ -20,11 +20,12 @@ parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }
 bytes = { workspace = true }
 futures = { workspace = true }
-wasmtime = "7.0.0"
-wasmtime-wasi = { version = "7.0.0", features = ["sync"] }
-wasi-common = { version = "7.0.0" }
+wasmtime = "10.0.1"
+wasmtime-wasi = { version = "10.0.1", features = ["sync"] }
+wasi-common = { version = "10.0.1" }
 cfg-if = "1.0.0"
 anyhow = { version = "1.0" }
+once_cell = "1.18"
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/crates/wasmrs-wasmtime/examples/request.rs
+++ b/crates/wasmrs-wasmtime/examples/request.rs
@@ -37,8 +37,9 @@ async fn main() -> anyhow::Result<()> {
   env_logger::init();
   let args = Args::parse();
 
-  let module_bytes = std::fs::read(args.module)?;
-  let engine = WasmtimeBuilder::new(&module_bytes)
+  let module_bytes = std::fs::read(&args.module)?;
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes(&args.module, &module_bytes)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;

--- a/crates/wasmrs-wasmtime/src/engine_provider.rs
+++ b/crates/wasmrs-wasmtime/src/engine_provider.rs
@@ -15,7 +15,7 @@ use crate::wasmrs_wasmtime::{self};
 #[allow(missing_debug_implementations)]
 pub struct WasmtimeEngineProvider {
   module: Module,
-  engine: Arc<Engine>,
+  engine: Engine,
   linker: Linker<ProviderStore>,
   wasi_params: Option<WasiParams>,
   pub(crate) epoch_deadlines: Option<EpochDeadlines>,
@@ -50,15 +50,13 @@ impl Clone for WasmtimeEngineProvider {
 
 impl WasmtimeEngineProvider {
   /// Creates a new instance of a [WasmtimeEngineProvider] from a separately created [wasmtime::Engine].
-  pub(crate) fn new_with_engine(buf: &[u8], engine: Engine, wasi_params: Option<WasiParams>) -> Result<Self> {
-    let module = Module::new(&engine, buf).map_err(Error::Module)?;
-
+  pub(crate) fn new_with_engine(module: Module, engine: Engine, wasi_params: Option<WasiParams>) -> Result<Self> {
     let mut linker: Linker<ProviderStore> = Linker::new(&engine);
     wasmtime_wasi::add_to_linker(&mut linker, |s| s.wasi_ctx.as_mut().unwrap()).unwrap();
 
     Ok(WasmtimeEngineProvider {
       module,
-      engine: Arc::new(engine),
+      engine,
       wasi_params,
       linker,
       epoch_deadlines: None,

--- a/crates/wasmrs-wasmtime/tests/request_channel.rs
+++ b/crates/wasmrs-wasmtime/tests/request_channel.rs
@@ -11,7 +11,8 @@ static MODULE_BYTES: &[u8] = include_bytes!("../../../build/reqres_component.was
 
 #[test_log::test(tokio::test)]
 async fn test_req_channel_single() -> anyhow::Result<()> {
-  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes("reqres_component", MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;
@@ -59,7 +60,8 @@ async fn test_req_channel_single() -> anyhow::Result<()> {
 
 #[test_log::test(tokio::test)]
 async fn test_req_channel_multi() -> anyhow::Result<()> {
-  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes("reqres_component", MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;

--- a/crates/wasmrs-wasmtime/tests/request_response.rs
+++ b/crates/wasmrs-wasmtime/tests/request_response.rs
@@ -7,7 +7,8 @@ static MODULE_BYTES: &[u8] = include_bytes!("../../../build/reqres_component.was
 
 #[test_log::test(tokio::test)]
 async fn test_req_response() -> anyhow::Result<()> {
-  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes("reqres_component", MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;

--- a/crates/wasmrs-wasmtime/tests/request_stream.rs
+++ b/crates/wasmrs-wasmtime/tests/request_stream.rs
@@ -10,7 +10,8 @@ static MODULE_BYTES: &[u8] = include_bytes!("../../../build/reqres_component.was
 
 #[test_log::test(tokio::test)]
 async fn test_req_stream() -> anyhow::Result<()> {
-  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes("reqres_component", MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;

--- a/crates/wasmrs-wasmtime/tests/test_baseline.rs
+++ b/crates/wasmrs-wasmtime/tests/test_baseline.rs
@@ -22,7 +22,8 @@ fn callback(incoming: BoxFlux<Payload, PayloadError>) -> Result<BoxFlux<RawPaylo
 
 #[test_log::test(tokio::test)]
 async fn test_req_channel_callback() -> anyhow::Result<()> {
-  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes("baseline", MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;
@@ -66,7 +67,8 @@ async fn test_req_channel_callback() -> anyhow::Result<()> {
 
 #[test_log::test(tokio::test)]
 async fn test_req_res() -> anyhow::Result<()> {
-  let engine = WasmtimeBuilder::new(MODULE_BYTES)
+  let engine = WasmtimeBuilder::new()
+    .with_module_bytes("baseline", MODULE_BYTES)
     .wasi_params(WasiParams::default())
     .build()?;
   let host = wasmrs_host::Host::new(engine)?;


### PR DESCRIPTION
This PR enables a module cache that dependents can query and initialize wasm into, rather than forcing a module compile every time.

This PR also bumps wasmtime.